### PR TITLE
build: lock fatih/set to 0.1.0

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -35,7 +35,7 @@ import:
 - package: gopkg.in/eapache/queue.v1
   version: ^1.1.0
 - package: gopkg.in/fatih/set.v0
-  version: ^0.1.0
+  version: 0.1.0
 - package: gopkg.in/go-playground/validator.v8
   version: ^8.18.2
 testImport:


### PR DESCRIPTION
[fatih/set](https://github.com/fatih/set) which is archived looks like break changes after 0.1.0 -> 0.2.0. So locking version to 0.1.0 to help newbie build:)