### PR TITLE
syncmanager: pick the first candidate then break

### DIFF
--- a/net/syncmanager/syncmanager.go
+++ b/net/syncmanager/syncmanager.go
@@ -285,6 +285,7 @@ func (sm *SyncManager) startSync() {
 		// TODO(davec): Use a better algorithm to choose the best peer.
 		// For now, just pick the first available candidate.
 		bestPeer = peer
+		break
 	}
 
 	// Start syncing from the best peer if one was selected.


### PR DESCRIPTION
Hello.
It looks like we forget to break the loop after picking the first available candidate at syncmanager
