### PR TITLE
blockheader: fix String() method

### DIFF
--- a/model/block/blockheader.go
+++ b/model/block/blockheader.go
@@ -97,9 +97,10 @@ func (bh *BlockHeader) Unserialize(r io.Reader) error {
 }
 
 func (bh *BlockHeader) String() string {
+	hash := bh.GetHash()
 	return fmt.Sprintf("Block version : %d, hashPrevBlock : %s, hashMerkleRoot : %s,"+
 		"Time : %d, Bits : %d, nonce : %d, BlockHash : %s\n", bh.Version, bh.HashPrevBlock,
-		bh.MerkleRoot, bh.Time, bh.Bits, bh.Nonce, bh.GetHash())
+		&bh.MerkleRoot, bh.Time, bh.Bits, bh.Nonce, &hash)
 }
 func (bh *BlockHeader) GetSerializeList() []string {
 	dumplist := []string{"Version", "HashPrevBlock", "MerkleRoot", "Time", "Bits", "Nonce"}

--- a/model/block/blockheader.go
+++ b/model/block/blockheader.go
@@ -102,6 +102,7 @@ func (bh *BlockHeader) String() string {
 		"Time : %d, Bits : %d, nonce : %d, BlockHash : %s\n", bh.Version, bh.HashPrevBlock,
 		&bh.MerkleRoot, bh.Time, bh.Bits, bh.Nonce, &hash)
 }
+
 func (bh *BlockHeader) GetSerializeList() []string {
 	dumplist := []string{"Version", "HashPrevBlock", "MerkleRoot", "Time", "Bits", "Nonce"}
 	return dumplist


### PR DESCRIPTION
Hello.

The `util.Hash` had implemented the `fmt.Stringer` interface with `func (hash *Hash) String() string` which should be invoked with pointer rather than value.