### PR TITLE
persis/disk/db: typo about bw.bkey -> bw.bval

### DIFF
--- a/persist/db/db.go
+++ b/persist/db/db.go
@@ -366,7 +366,7 @@ func (bw *BatchWrapper) Write(key, val []byte) {
 	}
 	bw.sizeEst += 3 + k + len(bw.bkey) + v + len(bw.bval)
 	bw.bkey = bw.bkey[:0]
-	bw.bval = bw.bkey[:0]
+	bw.bval = bw.bval[:0]
 }
 
 func (bw *BatchWrapper) SizeEstimate() int {


### PR DESCRIPTION
Hello.

This typo error will cause the complex question (syncing block to disk) which took me several hours to debug :(. 

Sorry, no more tests now. But it will be better with more tests to keep the core module correct:)