### PR TITLE
fix global.InitPersistGlobal and optimize global.GetInstance

### DIFF
--- a/persist/global/global.go
+++ b/persist/global/global.go
@@ -59,13 +59,12 @@ func (pg *PersistGlobal) AddBlockSequenceID() {
 	pg.GlobalBlockSequenceID++
 }
 
-func InitPersistGlobal() *PersistGlobal {
-	cg := new(PersistGlobal)
-	cg.GlobalBlockFileInfo = make([]*block.BlockFileInfo, 0, 1000)
-	cg.GlobalDirtyFileInfo = make(map[int32]bool)
-	cg.GlobalDirtyBlockIndex = make(map[util.Hash]*blockindex.BlockIndex)
-	cg.GlobalMapBlocksUnlinked = make(map[*blockindex.BlockIndex][]*blockindex.BlockIndex)
-	return cg
+func InitPersistGlobal() {
+	persistGlobal = new(PersistGlobal)
+	persistGlobal.GlobalBlockFileInfo = make([]*block.BlockFileInfo, 0, 1000)
+	persistGlobal.GlobalDirtyFileInfo = make(map[int32]bool)
+	persistGlobal.GlobalDirtyBlockIndex = make(map[util.Hash]*blockindex.BlockIndex)
+	persistGlobal.GlobalMapBlocksUnlinked = make(map[*blockindex.BlockIndex][]*blockindex.BlockIndex)
 }
 
 func InitPruneState() *PruneState {
@@ -80,8 +79,5 @@ func InitPruneState() *PruneState {
 }
 
 func GetInstance() *PersistGlobal {
-	if persistGlobal == nil {
-		persistGlobal = InitPersistGlobal()
-	}
 	return persistGlobal
 }


### PR DESCRIPTION
global.InitPersistGlobal is not effective, if the variable persistGlobal is not  initialized,  then  global.GetInstance is not thread safe, the variable persistGlobal should be  initialized in InitPersistGlobal, after that,  the "if judgement" is unnecessary in GetInstance