### PR TITLE
 stack: avoid panic when asserts interface{} to bool

### DIFF
--- a/util/stack.go
+++ b/util/stack.go
@@ -99,7 +99,7 @@ func (s *Stack) SetTop(i int, value interface{}) bool {
 func (s *Stack) CountBool(val bool) int {
 	var count int
 	for _, e := range s.array {
-		if e.(bool) == val {
+		if v, ok := e.(bool); ok && v == val {
 			count++
 		}
 	}

--- a/util/stack_test.go
+++ b/util/stack_test.go
@@ -4,6 +4,28 @@ import (
 	"testing"
 )
 
+func TestStackCountBool(t *testing.T) {
+	stack := NewStack()
+	stack.Push(1)
+	stack.Push(2)
+	n := stack.CountBool(false)
+	if n > 0 {
+		t.Errorf("Want %d, got %d", 0, n)
+	}
+
+	stack.Push(false)
+	n = stack.CountBool(false)
+	if n != 1 {
+		t.Errorf("Want %d, got %d", 1, n)
+	}
+
+	stack.Push(true)
+	n = stack.CountBool(true)
+	if n != 1 {
+		t.Errorf("Want %d, got %d", 1, n)
+	}
+}
+
 func TestStack(t *testing.T) {
 
 	stack := NewStack()


### PR DESCRIPTION
The `stack.CountBool` may trigger a panic when try to asserts  non-bool value