### PR TITLE
 fix a problem that may lead to memory error

### DIFF
--- a/logic/lchain/lchain.go
+++ b/logic/lchain/lchain.go
@@ -40,7 +40,12 @@ func ConnectBlock(pblock *block.Block, pindex *blockindex.BlockIndex, view *utxo
 	}
 
 	// Verify that the view's current state corresponds to the previous lblock
-	hashPrevBlock := *pindex.Prev.GetBlockHash()
+	var hashPrevBlock *util.Hash
+	if pindex.Prev == nil {
+		hashPrevBlock = &util.Hash{}
+	} else {
+		hashPrevBlock = pindex.Prev.GetBlockHash()
+	}
 	gUtxo := utxo.GetUtxoCacheInstance()
 	bestHash, _ := gUtxo.GetBestBlock()
 	if !hashPrevBlock.IsEqual(&bestHash) {


### PR DESCRIPTION
when reindex, we may reuse the genesis block writen to the disk, then that
index.Prev is nil, and invoking IsEqual method will lead to memory error