### PR TITLE
perf: avoid static array copy in range expression

### DIFF
--- a/model/mempool/estimatefee.go
+++ b/model/mempool/estimatefee.go
@@ -522,7 +522,7 @@ func (ef *FeeEstimator) newEstimateFeeSet() *estimateFeeSet {
 	set := &estimateFeeSet{}
 
 	capacity := 0
-	for i, b := range ef.bin {
+	for i, b := range &ef.bin {
 		l := len(b)
 		set.bin[i] = uint32(l)
 		capacity += l
@@ -531,7 +531,7 @@ func (ef *FeeEstimator) newEstimateFeeSet() *estimateFeeSet {
 	set.feeRate = make([]SatoshiPerByte, capacity)
 
 	i := 0
-	for _, b := range ef.bin {
+	for _, b := range &ef.bin {
 		for _, o := range b {
 			set.feeRate[i] = o.feeRate
 			i++
@@ -668,7 +668,7 @@ func (ef *FeeEstimator) Save() FeeEstimatorState {
 	}
 
 	// Save all the right bins.
-	for _, list := range ef.bin {
+	for _, list := range &ef.bin {
 
 		binary.Write(w, binary.BigEndian, uint32(len(list)))
 


### PR DESCRIPTION
See Go issue for details: [https://github.com/golang/go/issues/15812](https://github.com/golang/go/issues/15812), reported by [go-critic](https://github.com/go-critic/go-critic)


