### PR TITLE
peer: fix goroutine leak when negotiate time > negotiateTimeout

### DIFF
--- a/peer/peer.go
+++ b/peer/peer.go
@@ -1925,7 +1925,7 @@ func (p *Peer) Disconnect() {
 func (p *Peer) start(phCh chan<- *PeerMessage) error {
 	log.Trace("Starting peer %s", p)
 
-	negotiateErr := make(chan error)
+	negotiateErr := make(chan error, 1)
 	go func() {
 		if p.inbound {
 			negotiateErr <- p.negotiateInboundProtocol()


### PR DESCRIPTION
It will cause goroutine leak because of blocking in sending the error to `negotiateErr` which is the unbuffered channel.

See POC as the following:

````golang
package main

import (
	"fmt"
	"runtime"
	"time"
)

func main() {
	ch := make(chan bool)
	go func() {
		time.Sleep(time.Second * 2) 
		ch <- true
	}()

	select {
	case <-time.After(time.Second * 1):
		fmt.Println("timeout")
	case <-ch:
		fmt.Println("recevive")
	}
	time.Sleep(3)
	fmt.Println(runtime.NumGoroutine()) // it should output 1 but 2
}
````