### PR TITLE
blockheader: show bh.HashPrevBlock rightly in String()

### DIFF
--- a/model/block/blockheader.go
+++ b/model/block/blockheader.go
@@ -102,7 +102,7 @@ func (bh *BlockHeader) Unserialize(r io.Reader) error {
 func (bh *BlockHeader) String() string {
 	hash := bh.GetHash()
 	return fmt.Sprintf("Block version : %d, hashPrevBlock : %s, hashMerkleRoot : %s,"+
-		"Time : %d, Bits : %d, nonce : %d, BlockHash : %s\n", bh.Version, bh.HashPrevBlock,
+		"Time : %d, Bits : %d, nonce : %d, BlockHash : %s\n", bh.Version, &bh.HashPrevBlock,
 		&bh.MerkleRoot, bh.Time, bh.Bits, bh.Nonce, &hash)
 }
 


### PR DESCRIPTION
The PR is a sister PR about [https://github.com/copernet/copernicus/pull/46](https://github.com/copernet/copernicus/pull/46), and I'm so sorry that [https://github.com/copernet/copernicus/pull/46](https://github.com/copernet/copernicus/pull/46) did not fix the blockheader.String() completely