### PR TITLE
return median time instead of 0, even when numNodes less than 11

### DIFF
--- a/model/blockindex/blockindex.go
+++ b/model/blockindex/blockindex.go
@@ -177,9 +177,9 @@ func (bIndex *BlockIndex) GetMedianTimePast() int64 {
 		return median[i] < median[j]
 	})
 
-	if len(median) < 11 {
-		return 0
-	}
+	//if len(median) < 11 {
+	//	return 0
+	//}
 	return median[numNodes/2]
 }
 


### PR DESCRIPTION
reference src/chain.h:413 in abc.