### PR TITLE
make it gracefully exit after received the `stop' rpc command

### DIFF
--- a/rpc/rpcserver.go
+++ b/rpc/rpcserver.go
@@ -583,7 +583,7 @@ func NewServer(config *ServerConfig) (*Server, error) {
 		statusLines: make(map[int]string),
 		//gbtWorkState:           newGbtWorkState(config.TimeSource), // todo open
 		helpCacher:             newHelpCacher(),
-		requestProcessShutdown: make(chan struct{}),
+		requestProcessShutdown: make(chan struct{}, 1),
 		quit: make(chan int),
 	}
 	if conf.Cfg.RPC.RPCUser != "" && conf.Cfg.RPC.RPCPass != "" {

--- a/signal.go
+++ b/signal.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"sync"
+	"time"
 )
 
 // shutdownRequestChannel is used to initiate shutdown from one of the
@@ -36,12 +37,14 @@ func interruptListener() <-chan struct{} {
 					"shutting down...", sig)
 
 			case <-shutdownRequestChannel:
-				log.Info("Shutdown requested.  " +
-					"shutting down...")
+				log.Info("Shutdown requested. shutting down...")
+				//sleep 1s to give the response message of 'stop' a chance to send out
+				time.Sleep(time.Second)
 			}
 
 			closeOnce.Do(
 				func() {
+					log.Error("[stop]3")
 					close(c)
 				})
 		}


### PR DESCRIPTION


1. make requestProcessShutdown a buffered channel, to receive the stop msg without blocking or missing the msg.
   see handleStop for details.
2. sleep 1s before exit, for the rpc reply of `stop' to send out."

https://github.com/copernet/copernicus/issues/105