### PR TITLE
Adding testing framework: Testify.  (run glide install needed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,4 @@ All documentation will be continually updated and can be found at [docs](https:/
 ## Acknowledgments
 * Thank [btcd](https://github.com/btcsuite/btcd) for full node bitcoin implementation with Go. [Click here for more details](https://www.copernicuscore.org/btcd.html)
 * Thank [secp256k1-go](https://github.com/btccom/secp256k1-go) for bindings to lib-secp256k1 for golang
+* Thank [testify](https://github.com/stretchr/testify) for convenient testing support 

--- a/glide.lock
+++ b/glide.lock
@@ -1,17 +1,10 @@
-hash: c63b5ff88264de70a61376808be9098cf27a2ef84b42f7527438a2847597ec8b
-updated: 2018-09-08T18:24:20.166416+08:00
+hash: 6e9abcec2dc7e946031ac8cd3b0b7f677a0b21fe700757a6318a24b311554aa4
+updated: 2018-09-29T16:24:24.475323+08:00
 imports:
 - name: github.com/astaxie/beego
   version: 053a075344c118a5cc41981b29ef612bb53d20ca
   subpackages:
-  - config
-  - context
-  - context/param
-  - grace
   - logs
-  - session
-  - toolbox
-  - utils
 - name: github.com/copernet/secp256k1
   version: 5ace5d10cf35281acba5dd8b7a5da934167db9c4
 - name: github.com/copernet/secp256k1-go
@@ -65,7 +58,11 @@ imports:
 - name: github.com/spf13/pflag
   version: 3ebe029320b2676d667ae88da602a5f854788a8a
 - name: github.com/spf13/viper
-  version: 8fb642006536c8d3760c99d4fa2389f5e2205631
+  version: 2c12c60302a5a0e62ee102ca9bc996277c2f64f5
+- name: github.com/stretchr/testify
+  version: f35b8ab0b5a2cef36673838d662e249dd9c94686
+  subpackages:
+  - assert
 - name: github.com/syndtr/goleveldb
   version: c4c61651e9e37fa117f53c5a906d3b63090d8445
   subpackages:
@@ -82,10 +79,8 @@ imports:
   - leveldb/table
   - leveldb/util
 - name: golang.org/x/crypto
-  version: a49355c7e3f8fe157a85be2f77e6e269a0f89602
+  version: 122d919ec1efcfb58483215da23f815853e24b81
   subpackages:
-  - acme
-  - acme/autocert
   - ripemd160
 - name: golang.org/x/sys
   version: 1b2967e3c290b7c545b3db0deeda16e9be4f98a2
@@ -106,38 +101,22 @@ imports:
   version: 5420a8b6744d3b0345ab293f6fcba19c978f1183
 testImports:
 - name: github.com/btcsuite/btcd
-  version: fdfc19097e7ac6b57035062056f5b7b4638b8898
+  version: 2be2f12b358dc57d70b8f501b00be450192efbc3
   subpackages:
-  - blockchain
   - btcec
   - chaincfg
   - chaincfg/chainhash
-  - database
-  - peer
-  - txscript
   - wire
-- name: github.com/btcsuite/btclog
-  version: 84c8d2346e9fc8c7b947e243b9c24e6df9fd206a
 - name: github.com/btcsuite/btcutil
-  version: ab6388e0c60ae4834a1f57511e20c17b5f78be4b
+  version: 501929d3d046174c3d39f0ea54ece471aa17238c
   subpackages:
   - base58
   - bech32
-  - bloom
-- name: github.com/gopherjs/gopherjs
-  version: 0892b62f0d9fb5857760c3cfca837207185117ee
+- name: github.com/pmezard/go-difflib
+  version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
-  - js
-- name: github.com/jtolds/gls
-  version: 77f18212c9c7edc9bd6a33d383a7b545ce62f064
-- name: github.com/smartystreets/assertions
-  version: eb5b59917fa21f01252cee37e84631c7fb502d82
-  subpackages:
-  - internal/go-render/render
-  - internal/oglematchers
+  - difflib
 - name: github.com/smartystreets/goconvey
   version: 9e8dc3f972df6c8fcc0375ef492c24d0bb204857
   subpackages:
   - convey
-  - convey/gotest
-  - convey/reporting

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,7 +6,6 @@ import:
   - logs
 - package: github.com/copernet/secp256k1-go
 - package: github.com/copernet/secp256k1
-
 - package: github.com/davecgh/go-spew
   version: ^1.1.0
   subpackages:
@@ -36,7 +35,8 @@ import:
 - package: golang.org/x/crypto
   subpackages:
   - ripemd160
-
+- package: github.com/stretchr/testify
+  version: v1.2.2
 testImport:
 - package: github.com/smartystreets/goconvey
   version: ^1.6.3

--- a/model/opcodes/parsedopcode_test.go
+++ b/model/opcodes/parsedopcode_test.go
@@ -1,6 +1,7 @@
 package opcodes
 
 import (
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
@@ -27,29 +28,17 @@ func TestCheckMinimalPush(t *testing.T) {
 	testParseOpCode.OpValue = OP_0
 	testParseOpCode.Length = 1
 	testParseOpCode.Data = nil
-	check := testParseOpCode.CheckMinimalDataPush()
-	if !check {
-		t.Error("should not have error, because the datalenth is 0 and OpCode id OP_0 ")
-	}
+	assert.True(t, testParseOpCode.CheckMinimalDataPush())
 
 	testParseOpCode.OpValue = OP_15
-	check = testParseOpCode.CheckMinimalDataPush()
-	if check {
-		t.Error("should have error, because the datalenth is 0")
-	}
+	assert.False(t, testParseOpCode.CheckMinimalDataPush(), "check should failed, because the datalenth is 0")
 
 	testParseOpCode.Data = append(testParseOpCode.Data, 15)
-	check = testParseOpCode.CheckMinimalDataPush()
-	if !check {
-		t.Error("should not have error, because the data is a single 15 and OpCode id OP_15 ")
-	}
+	assert.True(t, testParseOpCode.CheckMinimalDataPush())
 
 	testParseOpCode.Data = append(testParseOpCode.Data, 15, 1, 2, 3, 4, 5, 6)
 	testParseOpCode.OpValue = byte(len(testParseOpCode.Data))
-	check = testParseOpCode.CheckMinimalDataPush()
-	if !check {
-		t.Error("should not have error, because the datalenth is 7 and OpCode id 7 ")
-	}
+	assert.True(t, testParseOpCode.CheckMinimalDataPush())
 }
 
 func TestBytes(t *testing.T) {

--- a/rpc/btcjson/jsonrpc_test.go
+++ b/rpc/btcjson/jsonrpc_test.go
@@ -6,7 +6,6 @@ package btcjson
 
 import (
 	"encoding/json"
-	"github.com/btcsuite/btcd/btcjson"
 	"reflect"
 	"testing"
 )
@@ -161,14 +160,9 @@ func TestRPCError(t *testing.T) {
 
 func TestUnmarshalRequest(t *testing.T) {
 	str := `{"version": "1.1", "method": "getblockcount", "params": [], "id": 40}`
-	var request btcjson.Request
+	var request Request
 	err := json.Unmarshal([]byte(str), &request)
 	if err != nil {
 		t.Error(err)
 	}
-	//str = `{"version": "1.1", "method": "getblockcount", "params": {}, "id": 40}`
-	//err = jsoniter.Unmarshal([]byte(str), &request)
-	//if err != nil {
-	//	t.Error(err)
-	//}
 }


### PR DESCRIPTION

adding Testify testing framework, to

1. make testing output more clear:
   
```
--- FAIL: TestCheckMinimalPush (0.00s)
    <autogenerated>:1:
        	Error Trace:	parsedopcode_test.go:34
        	Error:      	Should be true
        	Test:       	TestCheckMinimalPush
        	Messages:   	should fail, has length but data is nil
FAIL
```

2. make testing code short and concise.


