### PR TITLE
fix error merkleroot value of new generated block called by generate rpc command

### DIFF
--- a/rpc/certgen.go
+++ b/rpc/certgen.go
@@ -113,7 +113,7 @@ func NewTLSCertPair(organization string, validUntil time.Time, extraHosts []stri
 
 		KeyUsage: x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature |
 			x509.KeyUsageCertSign,
-		IsCA: true, // so can sign self.
+		IsCA:                  true, // so can sign self.
 		BasicConstraintsValid: true,
 
 		DNSNames:    dnsNames,

--- a/rpc/rpcblockchain.go
+++ b/rpc/rpcblockchain.go
@@ -18,6 +18,7 @@ import (
 	"github.com/copernet/copernicus/rpc/btcjson"
 	"github.com/copernet/copernicus/util"
 	"gopkg.in/fatih/set.v0"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -880,6 +881,11 @@ func handleWaitForBlockHeight(s *Server, cmd interface{}, closeChan <-chan struc
 	c := cmd.(*btcjson.WaitForBlockHeightCmd)
 	height := c.Height
 	timeout := *c.Timeout
+
+	if timeout == 0 {
+		//0 indicates no timeout.
+		timeout = math.MaxInt32
+	}
 
 	gchain := chain.GetInstance()
 	tipHeight := gchain.TipHeight()

--- a/service/mining/mining.go
+++ b/service/mining/mining.go
@@ -429,7 +429,7 @@ func IncrementExtraNonce(bk *block.Block, bindex *blockindex.BlockIndex) (extraN
 	buf.Write([]byte(CoinbaseFlag))
 
 	coinbaseScript := script.NewScriptRaw(buf.Bytes())
-	bk.Txs[0].GetIns()[0].SetScriptSig(coinbaseScript)
+	bk.Txs[0].UpdateInScript(0, coinbaseScript)
 
 	bk.Header.MerkleRoot = lmerkleroot.BlockMerkleRoot(bk.Txs, nil)
 


### PR DESCRIPTION
- when run functional test 'example_test.py', the block relay failed.
- logs shows, the merkleroot of new generated block is wrong.
       [E] [blockservice.go:69]  check block failed, please check: module: chain, global errcode: 4004,  errdesc: Unknown code (4004)
       [D] [blockservice.go:46]  processBlock failed ...

- fixed in mining.go:
   update script by UpdateInScript(0, coinbaseScript) which will update the coinbase hash when needed.


