### PR TITLE
[bugfix] update block size after coinbaseScript updated

### DIFF
--- a/model/block/block.go
+++ b/model/block/block.go
@@ -51,6 +51,11 @@ func (bl *Block) SerializeSize() int {
 	if bl.serializesize != 0 {
 		return bl.serializesize
 	}
+
+	return bl.UpdateSerializeSize()
+}
+
+func (bl *Block) UpdateSerializeSize() int {
 	buf := bytes.NewBuffer(nil)
 	bl.Serialize(buf)
 	bl.serializesize = buf.Len()
@@ -99,6 +104,7 @@ func (bl *Block) GetHash() util.Hash {
 	bh := bl.Header
 	return bh.GetHash()
 }
+
 func NewBlock() *Block {
 	return &Block{}
 }

--- a/service/mining/mining.go
+++ b/service/mining/mining.go
@@ -430,6 +430,7 @@ func IncrementExtraNonce(bk *block.Block, bindex *blockindex.BlockIndex) (extraN
 
 	coinbaseScript := script.NewScriptRaw(buf.Bytes())
 	bk.Txs[0].UpdateInScript(0, coinbaseScript)
+	bk.UpdateSerializeSize()
 
 	bk.Header.MerkleRoot = lmerkleroot.BlockMerkleRoot(bk.Txs, nil)
 


### PR DESCRIPTION
before fix:
1. the generated block looks like this:
```
 Txs: ([]*tx.Tx) (len=1 cap=100000) {
  (*tx.Tx)(0xc0002523c0)(  ins:
 0 , PreviousOutPoint: OutPoint ( hash:0000000000000000000000000000000000000000000000000000000000000000 index: 4294967295)  , script:010000000000000001000000000000002f4542332e322f , Sequence:4294967295 
  outs:
 0 , Value :5000000000 Script:
)
 },
 serializesize: (int) 143,
```

2. because serializesize is incorrect.
the block saved to disk will be corrupted.

after peer ask the same block, the loaded block will look like this:
```
 Txs: ([]*tx.Tx) (len=1 cap=1) {
  (*tx.Tx)(0xc0001c6ea0)(  ins:
 0 , PreviousOutPoint: OutPoint ( hash:0000000000000000000000000000000000000000000000000000000000000000 index: 4294967295)  , script:010000000000000001000000000000002f454233b50000 , Sequence:256 
outs:
)
 },
 serializesize: (int) 0,
```







