### PR TITLE
fix panic, when running functional test invalidtxrequest.py

### DIFF
--- a/errcode/mempool.go
+++ b/errcode/mempool.go
@@ -12,7 +12,6 @@ const (
 	AlreadHaveTx
 	Nomature
 	ManyUnspendDepend
-	TooMinFeeRate
 	ErrorNotExistsInMemMap
 )
 
@@ -22,7 +21,6 @@ var merrToString = map[MemPoolErr]string{
 	AlreadHaveTx:      "The transaction already in mempool",
 	Nomature:          "Non-BIP68-final",
 	ManyUnspendDepend: "The transaction depend many unspend transaction",
-	TooMinFeeRate:     "The transaction's feerate is too minimal",
 }
 
 func (me MemPoolErr) String() string {

--- a/errcode/mempool_test.go
+++ b/errcode/mempool_test.go
@@ -15,7 +15,6 @@ func TestMemPoolErr_String(t *testing.T) {
 		{AlreadHaveTx, "The transaction already in mempool"},
 		{Nomature, "Non-BIP68-final"},
 		{ManyUnspendDepend, "The transaction depend many unspend transaction"},
-		{TooMinFeeRate, "The transaction's feerate is too minimal"},
 		{ErrorNotExistsInMemMap, "Unknown code (" + strconv.Itoa(int(ErrorNotExistsInMemMap)) + ")"},
 	}
 

--- a/logic/ltx/ltx.go
+++ b/logic/ltx/ltx.go
@@ -126,11 +126,7 @@ func CheckRegularTransaction(transaction *tx.Tx) error {
 	//check inputs
 	var scriptVerifyFlags = uint32(script.StandardScriptVerifyFlags)
 	if !model.ActiveNetParams.RequireStandard {
-		configVerifyFlags, err := strconv.Atoi(conf.Cfg.Script.PromiscuousMempoolFlags)
-		if err != nil {
-			panic("config PromiscuousMempoolFlags err")
-		}
-		scriptVerifyFlags = uint32(configVerifyFlags) | script.ScriptEnableSigHashForkID
+		scriptVerifyFlags = promiscuousMempoolFlags() | script.ScriptEnableSigHashForkID
 	}
 	scriptVerifyFlags |= extraFlags
 
@@ -172,6 +168,14 @@ func CheckRegularTransaction(transaction *tx.Tx) error {
 	}
 
 	return nil
+}
+
+func promiscuousMempoolFlags() uint32 {
+	flag, err := strconv.Atoi(conf.Cfg.Script.PromiscuousMempoolFlags)
+	if err != nil {
+		return uint32(script.StandardScriptVerifyFlags)
+	}
+	return uint32(flag)
 }
 
 // CheckBlockTransactions block service use these 3 func to check transactions or to apply transaction while connecting block to active chain


### PR DESCRIPTION
fix panic log:

```
panic: config PromiscuousMempoolFlags err

goroutine 83 [running]:
github.com/copernet/copernicus/logic/ltx.CheckRegularTransaction(0xc0000be660, 0x0, 0x0)
	/Users/bj1809120051/.go/src/github.com/copernet/copernicus/logic/ltx/ltx.go:131 +0xb32
```