### PR TITLE
[tx] make tx reject msg with short and concise inner error description.

### DIFF
--- a/errcode/error.go
+++ b/errcode/error.go
@@ -78,14 +78,27 @@ func NewError(errCode fmt.Stringer, desc string) error {
 	}
 }
 
+func MakeError(code RejectCode, format string, innerErr error) error {
+	return NewError(code, fmt.Sprintf(format, shortDesc(innerErr)))
+}
+
 func IsRejectCode(err error) (RejectCode, string, bool) {
-	pe, ok := err.(ProjectError)
-	if ok && pe.ErrorCode != nil {
-		switch t := pe.ErrorCode.(type) {
+	e, ok := err.(ProjectError)
+	if ok && e.ErrorCode != nil {
+		switch t := e.ErrorCode.(type) {
 		case RejectCode:
-			return t, pe.Desc, true
+			return t, e.Desc, true
 		}
 	}
 
 	return 0, "", false
+}
+
+func shortDesc(err error) string {
+	e, ok := err.(ProjectError)
+	if ok && e.ErrorCode != nil {
+		return e.ErrorCode.String()
+	}
+
+	return e.Error()
 }


### PR DESCRIPTION

```
2018-10-11 12:36:19.493000 TestFramework.mininode (DEBUG): Received message from 127.0.0.1:15406: msg_reject: b'tx' 16 b'mandatory-script-verify-flag-failed (module: script, global errcode: 1023,  desc: Invalid OP_IF construction)' [a51e9b1d17c216582faa8d83420d8a8f789829d8201a6aa15943de461c77cf5a]

```

to 

```
2018-10-11 14:34:47.416000 TestFramework.mininode (DEBUG): Received message from 127.0.0.1:12744: msg_reject: b'tx' 16 b'mandatory-script-verify-flag-failed (Invalid OP_IF construction)' [a51e9b1d17c216582faa8d83420d8a8f789829d8201a6aa15943de461c77cf5a]
```