### PR TITLE
the branch of headers-first function

### DIFF
--- a/conf/conf.go
+++ b/conf/conf.go
@@ -302,6 +302,9 @@ func InitConfig(args []string) *Configuration {
 	if opts.MaxTimeAdjustment > 0 {
 		config.P2PNet.MaxTimeAdjustment = opts.MaxTimeAdjustment
 	}
+	if len(opts.AssumeValid) > 0 {
+		config.Chain.AssumeValid = opts.AssumeValid
+	}
 
 	return config
 }

--- a/conf/opts.go
+++ b/conf/opts.go
@@ -34,6 +34,7 @@ type Opts struct {
 	SpendZeroConfChange            uint8  `long:"spendzeroconfchange" default:"1"`
 	MaxTimeAdjustment              uint64 `long:"maxtimeadjustment" default:"4200" description:"Maximum allowed median peer time offset adjustment. Local perspective of time may be influenced by peers forward or backward by this amount."`
 	MinimumChainWork               string `long:"minimumchainwork"`
+	AssumeValid                    string `long:"assumevalid"`
 }
 
 func InitArgs(args []string) (*Opts, error) {

--- a/conf/opts.go
+++ b/conf/opts.go
@@ -33,6 +33,7 @@ type Opts struct {
 	MaxMempool                     int64  `long:"maxmempool" default:"300000000"`
 	SpendZeroConfChange            uint8  `long:"spendzeroconfchange" default:"1"`
 	MaxTimeAdjustment              uint64 `long:"maxtimeadjustment" default:"4200" description:"Maximum allowed median peer time offset adjustment. Local perspective of time may be influenced by peers forward or backward by this amount."`
+	MinimumChainWork               string `long:"minimumchainwork"`
 }
 
 func InitArgs(args []string) (*Opts, error) {

--- a/initmain.go
+++ b/initmain.go
@@ -13,6 +13,7 @@ import (
 	"github.com/copernet/copernicus/model"
 	"github.com/copernet/copernicus/model/chain"
 	"github.com/copernet/copernicus/model/mempool"
+	"github.com/copernet/copernicus/model/pow"
 	"github.com/copernet/copernicus/model/utxo"
 	"github.com/copernet/copernicus/model/wallet"
 	"github.com/copernet/copernicus/persist"
@@ -35,6 +36,7 @@ func appInitMain(args []string) {
 	} else if conf.Cfg.P2PNet.RegTest {
 		model.SetRegTestParams()
 	}
+	pow.UpdateMinimumChainWork()
 
 	fmt.Println("Current data dir:\033[0;32m", conf.DataDir, "\033[0m")
 

--- a/logic/lblockindex/lblockindex.go
+++ b/logic/lblockindex/lblockindex.go
@@ -72,6 +72,10 @@ func LoadBlockIndexDB() bool {
 			branch = append(branch, index)
 		}
 
+		if index.Prev != nil {
+			index.BuildSkip()
+		}
+
 		if index.IsValid(blockindex.BlockValidTree) {
 			idxBestHeader := gChain.GetIndexBestHeader()
 			if idxBestHeader == nil ||

--- a/logic/lblockindex/lblockindex.go
+++ b/logic/lblockindex/lblockindex.go
@@ -54,9 +54,9 @@ func LoadBlockIndexDB() bool {
 		index.TimeMax = timeMax
 		// We can link the chain of blocks for which we've received transactions
 		// at some point. Pruned nodes may have deleted the block.
-		if index.TxCount <= 0 {
-			log.Error("index's Txcount is 0 ")
-			panic("index's Txcount is 0 ")
+		if index.TxCount < 0 {
+			log.Error("index's Txcount is < 0 ")
+			panic("index's Txcount is < 0 ")
 		}
 		if index.Prev != nil {
 			if index.Prev.ChainTxCount != 0 {

--- a/logic/lblockindex/lblockindex.go
+++ b/logic/lblockindex/lblockindex.go
@@ -71,6 +71,14 @@ func LoadBlockIndexDB() bool {
 			index.ChainTxCount = index.TxCount
 			branch = append(branch, index)
 		}
+
+		if index.IsValid(blockindex.BlockValidTree) {
+			idxBestHeader := gChain.GetIndexBestHeader()
+			if idxBestHeader == nil ||
+				idxBestHeader.ChainWork.Cmp(&index.ChainWork) == -1 {
+				gChain.SetIndexBestHeader(index)
+			}
+		}
 	}
 	log.Debug("LoadBlockIndexDB, BlockIndexMap len:%d, Branch len:%d, Orphan len:%d",
 		len(GlobalBlockIndexMap), len(branch), gChain.ChainOrphanLen())

--- a/logic/lchain/lchain.go
+++ b/logic/lchain/lchain.go
@@ -80,8 +80,9 @@ func ConnectBlock(pblock *block.Block, pindex *blockindex.BlockIndex, view *utxo
 		// selection of any particular chain but makes validating some faster by
 		// effectively caching the result of part of the verification.
 		if bi := gChain.FindBlockIndex(chain.HashAssumeValid); bi != nil {
+			minimumChainWork := pow.MiniChainWork()
 			if bi.GetAncestor(pindex.Height) == pindex && tip.GetAncestor(pindex.Height) == pindex &&
-				tip.ChainWork.Cmp(pow.HashToBig(&params.MinimumChainWork)) > 0 {
+				tip.ChainWork.Cmp(&minimumChainWork) > 0 {
 				// This block is a member of the assumed verified chain and an
 				// ancestor of the best header. The equivalent time check
 				// discourages hashpower from extorting the network via DOS

--- a/logic/lchain/lchain.go
+++ b/logic/lchain/lchain.go
@@ -40,7 +40,6 @@ func IsInitialBlockDownload() bool {
 
 func ConnectBlock(pblock *block.Block, pindex *blockindex.BlockIndex, view *utxo.CoinsMap, fJustCheck bool) error {
 	gChain := chain.GetInstance()
-	tip := gChain.Tip()
 	start := time.Now()
 	params := gChain.GetParams()
 	// Check it again in case a previous version let a bad lblock in
@@ -81,8 +80,10 @@ func ConnectBlock(pblock *block.Block, pindex *blockindex.BlockIndex, view *utxo
 		// effectively caching the result of part of the verification.
 		if bi := gChain.FindBlockIndex(chain.HashAssumeValid); bi != nil {
 			minimumChainWork := pow.MiniChainWork()
-			if bi.GetAncestor(pindex.Height) == pindex && tip.GetAncestor(pindex.Height) == pindex &&
-				tip.ChainWork.Cmp(&minimumChainWork) > 0 {
+			pindexBestHeader := gChain.GetIndexBestHeader()
+			if bi.GetAncestor(pindex.Height) == pindex &&
+				pindexBestHeader.GetAncestor(pindex.Height) == pindex &&
+				pindexBestHeader.ChainWork.Cmp(&minimumChainWork) >= 0 {
 				// This block is a member of the assumed verified chain and an
 				// ancestor of the best header. The equivalent time check
 				// discourages hashpower from extorting the network via DOS
@@ -96,7 +97,8 @@ func ConnectBlock(pblock *block.Block, pindex *blockindex.BlockIndex, view *utxo
 				// further back. The test against nMinimumChainWork prevents the
 				// skipping when denied access to any chain at least as good as
 				// the expected chain.
-				fScriptChecks = (pow.GetBlockProofEquivalentTime(tip, pindex, tip, params)) <= 60*60*24*7*2
+				fScriptChecks = (pow.GetBlockProofEquivalentTime(
+					pindexBestHeader, pindex, pindexBestHeader, params)) <= 60*60*24*7*2
 			}
 		}
 	}

--- a/logic/lreindex/lreindex.go
+++ b/logic/lreindex/lreindex.go
@@ -194,6 +194,7 @@ func UnloadBlockIndex() {
 	globalChain := chain.GetInstance()
 	globalChain.InitLoad(indexMap, branch)
 	globalChain.ClearActive()
+	globalChain.SetIndexBestHeader(nil)
 
 	//TODO clear mempool
 }

--- a/main.go
+++ b/main.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"github.com/copernet/copernicus/log"
-	"github.com/copernet/copernicus/model/bitcointime"
 	"net/http"
 	_ "net/http/pprof"
 	"os"

--- a/main.go
+++ b/main.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/copernet/copernicus/log"
+	"github.com/copernet/copernicus/model/bitcointime"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
@@ -105,6 +107,7 @@ func main() {
 	args := os.Args
 	// Work around defer not working after os.Exit()
 	if err := bchMain(context.Background(), args); err != nil {
-		os.Exit(1)
+		log.Error("bchMain failed with err %+v", err)
+		panic("bchMain failed with err: " + err.Error())
 	}
 }

--- a/model/bitcoinparams.go
+++ b/model/bitcoinparams.go
@@ -121,11 +121,12 @@ var MainNetParams = BitcoinParams{
 		},
 
 		// The best chain should have at least this much work.
-		MinimumChainWork: *util.HashFromString("000000000000000000000000000000000000000000a0f3064330647e2f6c4828"),
+		MinimumChainWork: *util.HashFromString("000000000000000000000000000000000000000000d3376bca8890d888f00235"),
 
 		// By default assume that the signatures in ancestors of this block are
 		// valid.
-		DefaultAssumeValid: *util.HashFromString("000000000000000000e45ad2fbcc5ff3e85f0868dd8f00ad4e92dffabe28f8d2"),
+		// mainnet height 556767
+		DefaultAssumeValid: *util.HashFromString("0000000000000000004626ff6e3b936941d341c5932ece4357eeccac44e6d56c"),
 
 		UAHFHeight: 478558,
 
@@ -245,8 +246,9 @@ var TestNetParams = BitcoinParams{
 				Timeout:   1493596800,
 			},
 		},
-		MinimumChainWork:   *util.HashFromString("00000000000000000000000000000000000000000000002a650f6ff7649485da"),
-		DefaultAssumeValid: *util.HashFromString("0000000000327972b8470c11755adf8f4319796bafae01f5a6650490b98a17db"),
+		MinimumChainWork:   *util.HashFromString("00000000000000000000000000000000000000000000003e28ffb60a2b69f5f0"),
+		// testnet height 1266000
+		DefaultAssumeValid: *util.HashFromString("0000000000000102b62e613c19671226fc8e098d4f89cf8b8da3f73aca8590e1"),
 		UAHFHeight:         1155875,
 		DAAHeight:          1188697,
 		// May 15, 2018 hard fork

--- a/model/bitcoinparams.go
+++ b/model/bitcoinparams.go
@@ -26,6 +26,8 @@ var (
 	// 2^255 -1
 	regressingPowLimit = new(big.Int).Sub(new(big.Int).Lsh(bigOne, 255), bigOne)
 	testNetPowLimit    = new(big.Int).Sub(new(big.Int).Lsh(bigOne, 224), bigOne)
+
+	miniChainWork big.Int
 )
 
 type ChainTxData struct {

--- a/model/bitcoinparams.go
+++ b/model/bitcoinparams.go
@@ -246,7 +246,7 @@ var TestNetParams = BitcoinParams{
 				Timeout:   1493596800,
 			},
 		},
-		MinimumChainWork:   *util.HashFromString("00000000000000000000000000000000000000000000003e28ffb60a2b69f5f0"),
+		MinimumChainWork: *util.HashFromString("00000000000000000000000000000000000000000000003e28ffb60a2b69f5f0"),
 		// testnet height 1266000
 		DefaultAssumeValid: *util.HashFromString("0000000000000102b62e613c19671226fc8e098d4f89cf8b8da3f73aca8590e1"),
 		UAHFHeight:         1155875,

--- a/model/bitcoinparams.go
+++ b/model/bitcoinparams.go
@@ -190,8 +190,8 @@ var MainNetParams = BitcoinParams{
 		{504031, util.HashFromString("0000000000000000011ebf65b60d0a3de80b8175be709d653b4c1a1beeb6ab9c")},
 		// Monolith activation.
 		{530359, util.HashFromString("0000000000000000011ada8bd08f46074f44a8f155396f43e38acf9501c49103")},
-		//Magnetic anomaly activation.
-		//{556767, util.HashFromString("0000000000000000004626ff6e3b936941d341c5932ece4357eeccac44e6d56c")},
+		// Magnetic anomaly activation.
+		{556767, util.HashFromString("0000000000000000004626ff6e3b936941d341c5932ece4357eeccac44e6d56c")},
 	},
 	MineBlocksOnDemands: false,
 	// Enforce current block version once majority of the network has

--- a/model/blockindex/blockindex.go
+++ b/model/blockindex/blockindex.go
@@ -39,7 +39,7 @@ type BlockIndex struct {
 	Prev *BlockIndex
 
 	// pointer to the index of some further predecessor of this block
-	//Skip *BlockIndex
+	Skip *BlockIndex
 
 	// height of the entry in the chain. The genesis block has height 0；
 	Height int32
@@ -78,7 +78,7 @@ func (bIndex *BlockIndex) SetNull() {
 	bIndex.Header.SetNull()
 	bIndex.blockHash = util.Hash{}
 	bIndex.Prev = nil
-	//bIndex.Skip = nil
+	bIndex.Skip = nil
 
 	bIndex.Height = 0
 	bIndex.File = -1
@@ -238,15 +238,24 @@ func (bIndex *BlockIndex) GetAncestor(height int32) *BlockIndex {
 	if height == bIndex.Height {
 		return bIndex
 	}
-	indexWalk := bIndex
-	for indexWalk.Prev != nil {
-		if indexWalk.Prev.Height == height {
-			return indexWalk.Prev
+	pindexWalk := bIndex
+	heightWalk := bIndex.Height
+	for heightWalk > height {
+		heightSkip := getSkipHeight(heightWalk)
+		heightSkipPrev := getSkipHeight(heightWalk - 1)
+		if pindexWalk.Skip != nil &&
+			(heightSkip == height || (heightSkip > height &&
+				!(heightSkipPrev < heightSkip-2 &&
+					heightSkipPrev >= height))) {
+			// Only follow pskip if pprev->pskip isn't better than pskip->pprev.
+			pindexWalk = pindexWalk.Skip
+			heightWalk = heightSkip
+		} else {
+			pindexWalk = pindexWalk.Prev
+			heightWalk--
 		}
-		indexWalk = indexWalk.Prev
 	}
-
-	return indexWalk
+	return pindexWalk
 }
 
 func (bIndex *BlockIndex) String() string {
@@ -314,4 +323,30 @@ func (bIndex *BlockIndex) IsMagneticAnomalyJustEnabled() bool {
 
 	return !model.IsMagneticAnomalyEnabled(bIndex.Prev.GetMedianTimePast()) &&
 		model.IsMagneticAnomalyEnabled(bIndex.GetMedianTimePast())
+}
+
+// invertLowestOne Turn the lowest '1' bit in the binary representation of a number into a '0'.
+func invertLowestOne(n int32) int32 {
+	return n & (n - 1)
+}
+
+// getSkipHeight Compute what height to jump back to with the CBlockIndex::pskip pointer/
+func getSkipHeight(height int32) int32 {
+	if height < 2 {
+		return 0
+	}
+
+	// Determine which height to jump back to. Any number strictly lower than
+	// height is acceptable, but the following expression seems to perform well
+	// in simulations (max 110 steps to go back up to 2**18 blocks).
+	if height&1 != 0 {
+		return invertLowestOne(invertLowestOne(height-1)) + 1
+	}
+	return invertLowestOne(height)
+}
+
+func (bIndex *BlockIndex) BuildSkip() {
+	if bIndex.Prev != nil {
+		bIndex.Skip = bIndex.Prev.GetAncestor(getSkipHeight(bIndex.Height))
+	}
 }

--- a/model/blockindex/blockindex.go
+++ b/model/blockindex/blockindex.go
@@ -251,6 +251,9 @@ func (bIndex *BlockIndex) GetAncestor(height int32) *BlockIndex {
 			pindexWalk = pindexWalk.Skip
 			heightWalk = heightSkip
 		} else {
+			if pindexWalk.Prev == nil {
+				return nil
+			}
 			pindexWalk = pindexWalk.Prev
 			heightWalk--
 		}

--- a/model/chain/chain.go
+++ b/model/chain/chain.go
@@ -570,6 +570,7 @@ func (c *Chain) AddToIndexMap(bi *blockindex.BlockIndex) error {
 		bi.Height = pre.Height + 1
 	}
 	if pre != nil {
+		bi.BuildSkip()
 		if pre.TimeMax > bi.TimeMax {
 			bi.TimeMax = pre.TimeMax
 		}

--- a/model/chain/chain.go
+++ b/model/chain/chain.go
@@ -619,3 +619,7 @@ func (c *Chain) BuildForwardTree() (forward map[*blockindex.BlockIndex][]*blocki
 	}
 	return
 }
+
+func (c *Chain) CanDirectFetch() bool {
+	return int64(c.Tip().GetBlockTime()) > util.GetAdjustedTime() * int64(c.params.TargetTimePerBlock)
+}

--- a/model/chain/chain.go
+++ b/model/chain/chain.go
@@ -621,5 +621,5 @@ func (c *Chain) BuildForwardTree() (forward map[*blockindex.BlockIndex][]*blocki
 }
 
 func (c *Chain) CanDirectFetch() bool {
-	return int64(c.Tip().GetBlockTime()) > util.GetAdjustedTime() - int64(c.params.TargetTimePerBlock) * 20
+	return int64(c.Tip().GetBlockTime()) > util.GetAdjustedTime()-int64(c.params.TargetTimePerBlock)*20
 }

--- a/model/chain/chain.go
+++ b/model/chain/chain.go
@@ -638,7 +638,7 @@ func (c *Chain) BuildForwardTree() (forward map[*blockindex.BlockIndex][]*blocki
 }
 
 func (c *Chain) CanDirectFetch() bool {
-	return int64(c.Tip().GetBlockTime()) > util.GetAdjustedTime()-int64(c.params.TargetTimePerBlock)*20
+	return int64(c.Tip().GetBlockTime()) > util.GetAdjustedTimeSec()-int64(c.params.TargetTimePerBlock)*20
 }
 
 func (c *Chain) GetIndexBestHeader() *blockindex.BlockIndex {

--- a/model/chain/chain.go
+++ b/model/chain/chain.go
@@ -3,6 +3,7 @@ package chain
 import (
 	"github.com/copernet/copernicus/model"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -56,7 +57,8 @@ func InitGlobalChain() {
 		globalChain = NewChain()
 	}
 	if len(conf.Cfg.Chain.AssumeValid) > 0 {
-		hash, err := util.GetHashFromStr(conf.Cfg.Chain.AssumeValid)
+		assumeValid := strings.TrimPrefix(conf.Cfg.Chain.AssumeValid, "0x")
+		hash, err := util.GetHashFromStr(assumeValid)
 		if err != nil {
 			panic("AssumeValid config err")
 		}

--- a/model/chain/chain.go
+++ b/model/chain/chain.go
@@ -621,5 +621,5 @@ func (c *Chain) BuildForwardTree() (forward map[*blockindex.BlockIndex][]*blocki
 }
 
 func (c *Chain) CanDirectFetch() bool {
-	return int64(c.Tip().GetBlockTime()) > util.GetAdjustedTime() * int64(c.params.TargetTimePerBlock)
+	return int64(c.Tip().GetBlockTime()) > util.GetAdjustedTime() - int64(c.params.TargetTimePerBlock) * 20
 }

--- a/model/chain/chain.go
+++ b/model/chain/chain.go
@@ -21,19 +21,22 @@ import (
 
 // Chain An in-memory blIndexed chain of blocks.
 type Chain struct {
-	active      []*blockindex.BlockIndex
-	branch      []*blockindex.BlockIndex
-	waitForTx   map[util.Hash]*blockindex.BlockIndex
-	orphan      map[util.Hash][]*blockindex.BlockIndex // preHash : *index
-	indexMap    map[util.Hash]*blockindex.BlockIndex   // selfHash :*index
-	newestBlock *blockindex.BlockIndex
-	receiveID   uint64
-	params      *model.BitcoinParams
+	active    []*blockindex.BlockIndex
+	branch    []*blockindex.BlockIndex
+	waitForTx map[util.Hash]*blockindex.BlockIndex
+	orphan    map[util.Hash][]*blockindex.BlockIndex // preHash : *index
+	indexMap  map[util.Hash]*blockindex.BlockIndex   // selfHash :*index
+	receiveID uint64
+	params    *model.BitcoinParams
 
 	// The notifications field stores a slice of callbacks to be executed on
 	// certain blockchain events.
 	notificationsLock sync.RWMutex
 	notifications     []NotificationCallback
+
+	// the current most chainwork index of blockheader
+	pindexBestHeader     *blockindex.BlockIndex
+	pindexBestHeaderLock sync.RWMutex
 
 	*SyncingState
 }
@@ -574,9 +577,20 @@ func (c *Chain) AddToIndexMap(bi *blockindex.BlockIndex) error {
 	}
 	log.Debug("AddToIndexMap:%s index height:%d", hash, bi.Height)
 	bi.RaiseValidity(blockindex.BlockValidTree)
+
+	c.tryUpdateIndexBestHeader(bi)
+
 	gPersist := persist.GetInstance()
 	gPersist.AddDirtyBlockIndex(bi)
 	return nil
+}
+
+func (c *Chain) tryUpdateIndexBestHeader(bi *blockindex.BlockIndex) {
+	idxBestHeader := c.GetIndexBestHeader()
+	if idxBestHeader == nil ||
+		idxBestHeader.ChainWork.Cmp(&bi.ChainWork) == -1 {
+		c.SetIndexBestHeader(bi)
+	}
 }
 
 func (c *Chain) AddToOrphan(bi *blockindex.BlockIndex) error {
@@ -622,4 +636,17 @@ func (c *Chain) BuildForwardTree() (forward map[*blockindex.BlockIndex][]*blocki
 
 func (c *Chain) CanDirectFetch() bool {
 	return int64(c.Tip().GetBlockTime()) > util.GetAdjustedTime()-int64(c.params.TargetTimePerBlock)*20
+}
+
+func (c *Chain) GetIndexBestHeader() *blockindex.BlockIndex {
+	c.pindexBestHeaderLock.RLock()
+	idx := c.pindexBestHeader
+	c.pindexBestHeaderLock.RUnlock()
+	return idx
+}
+
+func (c *Chain) SetIndexBestHeader(idx *blockindex.BlockIndex) {
+	c.pindexBestHeaderLock.Lock()
+	c.pindexBestHeader = idx
+	c.pindexBestHeaderLock.Unlock()
 }

--- a/model/chain/chain_test.go
+++ b/model/chain/chain_test.go
@@ -25,6 +25,7 @@ func TestMain(m *testing.M) {
 func getBlockIndex(indexPrev *blockindex.BlockIndex, timeInterval int64, bits uint32) *blockindex.BlockIndex {
 	blockIdx := new(blockindex.BlockIndex)
 	blockIdx.Prev = indexPrev
+	blockIdx.BuildSkip()
 	blockIdx.Height = indexPrev.Height + 1
 	blockIdx.Header.Time = indexPrev.Header.Time + uint32(timeInterval)
 	blockIdx.Header.Bits = bits

--- a/model/chain/syncing_state.go
+++ b/model/chain/syncing_state.go
@@ -1,7 +1,6 @@
 package chain
 
 import (
-	"github.com/copernet/copernicus/model"
 	"github.com/copernet/copernicus/model/blockindex"
 	"github.com/copernet/copernicus/model/pow"
 	"github.com/copernet/copernicus/util"
@@ -27,8 +26,8 @@ func isRecentTip(tip *blockindex.BlockIndex) bool {
 }
 
 func hasEnoughWork(tip *blockindex.BlockIndex) bool {
-	minWorkSum := pow.HashToBig(&model.ActiveNetParams.MinimumChainWork)
-	return tip.ChainWork.Cmp(minWorkSum) > 0
+	minWorkSum := pow.MiniChainWork()
+	return tip.ChainWork.Cmp(&minWorkSum) > 0
 }
 
 func (ds *SyncingState) IsAlmostSynced() bool {

--- a/model/pow/difficulty.go
+++ b/model/pow/difficulty.go
@@ -5,8 +5,10 @@
 package pow
 
 import (
+	"github.com/copernet/copernicus/conf"
 	"math"
 	"math/big"
+	"strings"
 
 	"github.com/copernet/copernicus/model"
 	"github.com/copernet/copernicus/model/blockindex"
@@ -21,6 +23,8 @@ var (
 	// oneLsh256 is 1 shifted left 256 bits.  It is defined here to avoid
 	// the overhead of creating it multiple times.
 	oneLsh256 = new(big.Int).Lsh(bigOne, 256)
+
+	miniChainWork big.Int
 )
 
 // HashToBig converts a chainHash.Hash into a big.Int that can be used to
@@ -188,4 +192,19 @@ func bits(w []big.Word) uint {
 		}
 	}
 	return 0
+}
+
+func MiniChainWork() big.Int {
+	return miniChainWork
+}
+
+func UpdateMinimumChainWork() {
+	miniChainWork = *HashToBig(&model.ActiveNetParams.MinimumChainWork)
+
+	mcw := strings.TrimPrefix(conf.Args.MinimumChainWork, "0x")
+
+	hash, err := util.GetHashFromStr(mcw)
+	if err == nil && !hash.IsNull() {
+		miniChainWork = *HashToBig(hash)
+	}
 }

--- a/model/pow/pow_test.go
+++ b/model/pow/pow_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestPowCalculateNextWorkRequired(t *testing.T) {
+	model.ActiveNetParams = &model.MainNetParams
+
 	lastRetargetTime := int64(1261130161) // Block #30240
 	var indexLast blockindex.BlockIndex
 	indexLast.Height = 32255

--- a/net/server/msghandle.go
+++ b/net/server/msghandle.go
@@ -85,11 +85,8 @@ out:
 				}
 				msg.Done <- struct{}{}
 			case *wire.MsgPing:
-				peerFrom.HandlePingMsg(data)
-				if peerFrom.Cfg.Listeners.OnPing != nil {
-					peerFrom.Cfg.Listeners.OnPing(peerFrom, data)
-				}
-				msg.Done <- struct{}{}
+				peerFrom.Cfg.Listeners.OnTransferMsgToBusinessPro(msg, msg.Done)
+
 			case *wire.MsgPong:
 				peerFrom.HandlePongMsg(data)
 				if peerFrom.Cfg.Listeners.OnPong != nil {

--- a/net/server/msghandle.go
+++ b/net/server/msghandle.go
@@ -84,8 +84,9 @@ out:
 					peerFrom.Cfg.Listeners.OnAddr(peerFrom, data)
 				}
 				msg.Done <- struct{}{}
+
 			case *wire.MsgPing:
-				peerFrom.Cfg.Listeners.OnTransferMsgToBusinessPro(msg, msg.Done)
+				mh.pings <- &PingMsg{sp: msg.Peerp, ping: data, done: msg.Done}
 
 			case *wire.MsgPong:
 				peerFrom.HandlePongMsg(data)

--- a/net/server/msghandle_test.go
+++ b/net/server/msghandle_test.go
@@ -216,9 +216,6 @@ func TestMsgHandle(t *testing.T) {
 			OnAddr: func(p *peer.Peer, msg *wire.MsgAddr) {
 				execCount["OnAddr"]++
 			},
-			OnPing: func(p *peer.Peer, msg *wire.MsgPing) {
-				execCount["OnPing"]++
-			},
 			OnPong: func(p *peer.Peer, msg *wire.MsgPong) {
 				execCount["OnPong"]++
 			},
@@ -247,6 +244,7 @@ func TestMsgHandle(t *testing.T) {
 			},
 			OnGetData: func(p *peer.Peer, msg *wire.MsgGetData, done chan<- struct{}) {
 				execCount["OnGetData"]++
+				done <- struct{}{}
 			},
 			OnGetBlocks: func(p *peer.Peer, msg *wire.MsgGetBlocks) {
 				execCount["OnGetBlocks"]++
@@ -330,11 +328,6 @@ func TestMsgHandle(t *testing.T) {
 		{
 			"OnAddr",
 			wire.NewMsgAddr(),
-			true,
-		},
-		{
-			"OnPing",
-			wire.NewMsgPing(42),
 			true,
 		},
 		{

--- a/net/server/server.go
+++ b/net/server/server.go
@@ -856,6 +856,10 @@ func (sp *serverPeer) OnFeeFilter(_ *peer.Peer, msg *wire.MsgFeeFilter) {
 	atomic.StoreInt64(&sp.feeFilter, msg.MinFee)
 }
 
+func (sp *serverPeer)OnReject(p *peer.Peer, msg *wire.MsgReject) {
+	log.Error("reject: %+v, from: %+v", msg, p)
+}
+
 // OnFilterAdd is invoked when a peer receives a filteradd bitcoin
 // message and is used by remote peers to add data to an already loaded bloom
 // filter.  The peer will be disconnected if a filter is not loaded when this
@@ -1908,6 +1912,7 @@ func newPeerConfig(sp *serverPeer) *peer.Config {
 			OnGetBlocks:  sp.OnGetBlocks,
 			OnGetHeaders: sp.OnGetHeaders,
 			OnFeeFilter:  sp.OnFeeFilter,
+			OnReject:     sp.OnReject,
 			//OnFilterAdd:   sp.OnFilterAdd,
 			//OnFilterClear: sp.OnFilterClear,
 			//OnFilterLoad:  sp.OnFilterLoad,

--- a/net/server/server.go
+++ b/net/server/server.go
@@ -2622,7 +2622,7 @@ func NewServer(chainParams *model.BitcoinParams, ts *util.MedianTime, interrupt 
 		banScoreChn:          make(chan *banScoreMsg),
 		connectedPeers:       make(map[string]*serverPeer),
 		banPeerFile:          filepath.Join(cfg.DataDir, "banpeers.json"),
-		txRelayer:			  NewTxRelayer(),
+		txRelayer:            NewTxRelayer(),
 	}
 
 	if cfg.P2PNet.TargetOutbound < 0 {

--- a/net/server/server.go
+++ b/net/server/server.go
@@ -72,7 +72,7 @@ const (
 	BanReasonNodeMisbehaving int = 1
 	BanReasonManuallyAdded   int = 2
 
-	// when peer is neer to tip, set its revertToInv to false back
+	// REVERT_TO_INV_DIFF when peer is neer to tip, set its revertToInv to false back
 	REVERT_TO_INV_DIFF = 7
 )
 

--- a/net/server/server.go
+++ b/net/server/server.go
@@ -769,7 +769,7 @@ func (sp *serverPeer) OnGetHeaders(_ *peer.Peer, msg *wire.MsgGetHeaders) {
 		return
 	}
 	header0hash := headers[0].GetHash()
-	sp.checkRevertToInv(&header0hash)
+	sp.CheckRevertToInv(&header0hash)
 
 	// Send found headers to the requesting peer.
 	blockHeaders := make([]*block.BlockHeader, len(headers))
@@ -777,19 +777,6 @@ func (sp *serverPeer) OnGetHeaders(_ *peer.Peer, msg *wire.MsgGetHeaders) {
 		blockHeaders[i] = &headers[i]
 	}
 	sp.QueueMessage(&wire.MsgHeaders{Headers: blockHeaders}, nil)
-}
-
-func (sp *serverPeer) checkRevertToInv(hash *util.Hash) {
-	if sp.RevertToInv() {
-		persist.CsMain.Lock()
-		defer persist.CsMain.Unlock()
-		gChain := chain.GetInstance()
-		tipheight := gChain.TipHeight()
-		locatorheight := gChain.GetSpendHeight(hash)
-		if tipheight < locatorheight + REVERT_TO_INV_DIFF {
-			sp.SetRevertToInv(false)
-		}
-	}
 }
 
 // enforceNodeBloomFlag disconnects the peer if the server is not configured to

--- a/net/server/server.go
+++ b/net/server/server.go
@@ -158,11 +158,11 @@ type relayMsg struct {
 
 type relayBlocksMsg struct {
 	invVects []*wire.InvVect
-	headers []*block.BlockHeader
+	headers  []*block.BlockHeader
 }
 
 type PingMsg struct {
-	sp *peer.Peer
+	sp   *peer.Peer
 	ping *wire.MsgPing
 	done chan<- struct{}
 }
@@ -770,7 +770,7 @@ func (sp *serverPeer) OnGetHeaders(_ *peer.Peer, msg *wire.MsgGetHeaders) {
 
 	// logic of Check to reset RevertToInv
 	gChain := chain.GetInstance()
-	for _, hash := range msg.BlockLocatorHashes{
+	for _, hash := range msg.BlockLocatorHashes {
 		bi := gChain.FindBlockIndex(*hash)
 		if bi != nil {
 			if gChain.Contains(bi) {
@@ -859,7 +859,7 @@ func (sp *serverPeer) OnFeeFilter(_ *peer.Peer, msg *wire.MsgFeeFilter) {
 	atomic.StoreInt64(&sp.feeFilter, msg.MinFee)
 }
 
-func (sp *serverPeer)OnReject(p *peer.Peer, msg *wire.MsgReject) {
+func (sp *serverPeer) OnReject(p *peer.Peer, msg *wire.MsgReject) {
 	log.Error("reject: %+v, from: %+v", msg, p)
 }
 
@@ -2600,7 +2600,7 @@ func NewServer(chainParams *model.BitcoinParams, ts *util.MedianTime, interrupt 
 		query:                make(chan interface{}),
 		relayInv:             make(chan relayMsg, cfg.P2PNet.MaxPeers),
 		relayBlocks:          make(chan relayBlocksMsg, cfg.P2PNet.MaxPeers),
-		pings:     		      make(chan *PingMsg, cfg.P2PNet.MaxPeers),
+		pings:                make(chan *PingMsg, cfg.P2PNet.MaxPeers),
 		minedBlock:           make(chan minedBlockMsg),
 		broadcast:            make(chan broadcastMsg, cfg.P2PNet.MaxPeers),
 		quit:                 make(chan struct{}),

--- a/net/server/server.go
+++ b/net/server/server.go
@@ -2687,8 +2687,8 @@ func initListeners(amgr *addrmgr.AddrManager, listenAddrs []string, services wir
 	for _, addr := range netAddrs {
 		listener, err := net.Listen(addr.Network(), addr.String())
 		if err != nil {
-			log.Warn("Can't listen on %s: %v", addr, err)
-			continue
+			log.Error("Can't listen on %s: %v", addr, err)
+			return nil, nil, err
 		}
 		listeners = append(listeners, listener)
 	}

--- a/net/server/server.go
+++ b/net/server/server.go
@@ -783,7 +783,7 @@ func (sp *serverPeer) checkResetRevert(msg *wire.MsgGetHeaders) {
 // message.
 func (sp *serverPeer) OnGetHeaders(_ *peer.Peer, msg *wire.MsgGetHeaders) {
 	// Ignore getheaders requests if not in sync.
-	if !sp.isWhitelisted && !sp.server.syncManager.IsCurrent() {
+	if !sp.IsWhitelisted() && !sp.server.syncManager.IsCurrent() {
 		log.Debug("syncmanager: chain is not update-to-date, ignore msgGetHeaders")
 		return
 	}

--- a/net/server/server.go
+++ b/net/server/server.go
@@ -2160,6 +2160,8 @@ func (s *Server) RelayUpdatedTipBlocks(event *chain.TipUpdatedEvent) {
 		blockIndexes = append(blockIndexes, tmp)
 
 		if len(blockIndexes) >= maxBlocksToAnnounce {
+			// large reorg happens, only relay highest one
+			blockIndexes = blockIndexes[0:1]
 			break
 		}
 	}

--- a/net/server/server.go
+++ b/net/server/server.go
@@ -156,6 +156,11 @@ type relayMsg struct {
 	data    interface{}
 }
 
+type relayBlocksMsg struct {
+	invVects []*wire.InvVect
+	headers []*block.BlockHeader
+}
+
 type minedBlockMsg struct {
 	block *block.Block
 	done  chan error
@@ -263,6 +268,7 @@ type Server struct {
 	clearBanned          chan *clearBannedMsg
 	query                chan interface{}
 	relayInv             chan relayMsg
+	relayBlocks             chan relayBlocksMsg
 	minedBlock           chan minedBlockMsg
 	broadcast            chan broadcastMsg
 	peerHeightsUpdate    chan updatePeerHeightsMsg
@@ -1587,6 +1593,31 @@ func (s *Server) loadBannedInfo() error {
 	return nil
 }
 
+func (s *Server) handleRelayBlocks(state *peerState, msg relayBlocksMsg) {
+	state.forAllPeers(func(sp *serverPeer) {
+		if !sp.Connected() {
+			return
+		}
+
+		headers := make([]*block.BlockHeader, 0)
+		if sp.WantsHeaders() {
+			for index, invVect := range msg.invVects {
+				if !sp.IsKnownInventory(invVect) {
+					sp.AddKnownInventory(invVect)
+					headers = append(headers, msg.headers[index])
+				}
+			}
+			sp.QueueBatchHeaders(headers)
+			return
+		}
+
+		for _, invVect := range msg.invVects {
+			sp.QueueInventory(invVect)
+		}
+	})
+}
+
+
 // handleRelayInvMsg deals with relaying inventory to peers that are not already
 // known to have it.  It is invoked from the peerHandler goroutine.
 func (s *Server) handleRelayInvMsg(state *peerState, msg relayMsg) {
@@ -2057,6 +2088,9 @@ out:
 		case invMsg := <-s.relayInv:
 			s.handleRelayInvMsg(state, invMsg)
 
+		case blocksMsg := <-s.relayBlocks:
+			s.handleRelayBlocks(state, blocksMsg)
+
 		case minedBlockMsg := <-s.minedBlock:
 			s.handleMinedBlock(minedBlockMsg)
 			// Message to broadcast to all connected peers except those
@@ -2096,6 +2130,7 @@ cleanup:
 		case <-s.donePeers:
 		case <-s.peerHeightsUpdate:
 		case <-s.relayInv:
+		case <-s.relayBlocks:
 		case <-s.broadcast:
 		case <-s.query:
 		default:
@@ -2159,6 +2194,10 @@ func (s *Server) RelayInventory(invVect *wire.InvVect, data interface{}) {
 	s.relayInv <- relayMsg{invVect: invVect, data: data}
 }
 
+func (s *Server) RelayBlocks(invVects []*wire.InvVect, headers []*block.BlockHeader) {
+	s.relayBlocks <- relayBlocksMsg{invVects: invVects, headers: headers}
+}
+
 func (s *Server) HandleMinedBlock(pblock *block.Block, done chan error) {
 	s.minedBlock <- minedBlockMsg{pblock, done}
 }
@@ -2180,13 +2219,16 @@ func (s *Server) RelayUpdatedTipBlocks(event *chain.TipUpdatedEvent) {
 		}
 	}
 
+	ivs := make([]*wire.InvVect, 0)
+	data := make([]*block.BlockHeader, 0)
 	for i := len(blockIndexes) - 1; i >= 0; i-- {
 		index := blockIndexes[i]
 		iv := wire.NewInvVect(wire.InvTypeBlock, index.GetBlockHash())
 
-		//TODO: relay inventory through headers message
-		s.RelayInventory(iv, index.GetBlockHeader())
+		ivs = append(ivs, iv)
+		data = append(data, index.GetBlockHeader())
 	}
+	s.RelayBlocks(ivs, data)
 }
 
 // BroadcastMessage sends msg to all peers currently connected to the server
@@ -2541,6 +2583,7 @@ func NewServer(chainParams *model.BitcoinParams, ts *util.MedianTime, interrupt 
 		clearBanned:          make(chan *clearBannedMsg),
 		query:                make(chan interface{}),
 		relayInv:             make(chan relayMsg, cfg.P2PNet.MaxPeers),
+		relayBlocks:          make(chan relayBlocksMsg, cfg.P2PNet.MaxPeers),
 		minedBlock:           make(chan minedBlockMsg),
 		broadcast:            make(chan broadcastMsg, cfg.P2PNet.MaxPeers),
 		quit:                 make(chan struct{}),

--- a/net/server/server.go
+++ b/net/server/server.go
@@ -556,6 +556,8 @@ func (sp *serverPeer) TransferMsgToBusinessPro(msg *peer.PeerMessage, done chan<
 		sp.server.syncManager.QueueMessgePool(dataType, msg.Peerp, done)
 	case *wire.MsgGetBlocks:
 		sp.server.syncManager.QueueGetBlocks(dataType, msg.Peerp, done)
+	case *wire.MsgPing:
+		sp.server.syncManager.QueuePing(dataType, msg.Peerp, done)
 	}
 }
 
@@ -703,6 +705,10 @@ func (sp *serverPeer) doGetData(msg *wire.MsgGetData, done chan<- struct{}) {
 		<-doneChan
 	}
 	done <- struct{}{}
+}
+
+func (sp *serverPeer) OnPing(p *peer.Peer, msg *wire.MsgPing) {
+	p.HandlePingMsg(msg)
 }
 
 func hashpointer2hashinstance(phash []*util.Hash) []util.Hash {
@@ -1915,6 +1921,7 @@ func newPeerConfig(sp *serverPeer) *peer.Config {
 			// not signed with its key.  We could verify against their key, but
 			// since the reference client is currently unwilling to support
 			// other implementations' alert messages, we will not relay theirs.
+			OnPing: sp.OnPing,
 			OnAlert: nil,
 		},
 		NewestBlock:       sp.newestBlock,

--- a/net/server/server.go
+++ b/net/server/server.go
@@ -2059,7 +2059,6 @@ func (s *Server) cycle() {
 
 	if !conf.Cfg.P2PNet.DisableDNSSeed {
 		// Add peers discovered through DNS to the address manager.
-		//connmgr.SeedFromDNS(chainparams.ActiveNetParams, defaultRequiredServices,
 		connmgr.SeedFromDNS(s.chainParams, defaultRequiredServices,
 			net.LookupIP, func(addrs []*wire.NetAddress) {
 				// Bitcoind uses a lookup of the dns seeder here. This

--- a/net/server/server.go
+++ b/net/server/server.go
@@ -161,6 +161,12 @@ type relayBlocksMsg struct {
 	headers []*block.BlockHeader
 }
 
+type PingMsg struct {
+	sp *peer.Peer
+	ping *wire.MsgPing
+	done chan<- struct{}
+}
+
 type minedBlockMsg struct {
 	block *block.Block
 	done  chan error
@@ -268,7 +274,8 @@ type Server struct {
 	clearBanned          chan *clearBannedMsg
 	query                chan interface{}
 	relayInv             chan relayMsg
-	relayBlocks             chan relayBlocksMsg
+	relayBlocks          chan relayBlocksMsg
+	pings                chan *PingMsg
 	minedBlock           chan minedBlockMsg
 	broadcast            chan broadcastMsg
 	peerHeightsUpdate    chan updatePeerHeightsMsg
@@ -705,10 +712,6 @@ func (sp *serverPeer) doGetData(msg *wire.MsgGetData, done chan<- struct{}) {
 		<-doneChan
 	}
 	done <- struct{}{}
-}
-
-func (sp *serverPeer) OnPing(p *peer.Peer, msg *wire.MsgPing) {
-	p.HandlePingMsg(msg)
 }
 
 func hashpointer2hashinstance(phash []*util.Hash) []util.Hash {
@@ -1610,23 +1613,21 @@ func (s *Server) handleRelayBlocks(state *peerState, msg relayBlocksMsg) {
 		}
 
 		headers := make([]*block.BlockHeader, 0)
-		if sp.WantsHeaders() {
-			for index, invVect := range msg.invVects {
-				if !sp.IsKnownInventory(invVect) {
-					sp.AddKnownInventory(invVect)
-					headers = append(headers, msg.headers[index])
-				}
+
+		for index, invVect := range msg.invVects {
+			if !sp.IsKnownInventory(invVect) {
+				sp.AddKnownInventory(invVect)
+				headers = append(headers, msg.headers[index])
 			}
-			sp.QueueBatchHeaders(headers)
-			return
 		}
 
-		for _, invVect := range msg.invVects {
-			sp.QueueInventory(invVect)
-		}
+		sp.QueueBatchHeaders(headers)
 	})
 }
 
+func (s *Server) handlePing(msg *PingMsg) {
+	msg.sp.HandlePingMsg(msg.ping.Nonce, msg.done)
+}
 
 // handleRelayInvMsg deals with relaying inventory to peers that are not already
 // known to have it.  It is invoked from the peerHandler goroutine.
@@ -1926,7 +1927,6 @@ func newPeerConfig(sp *serverPeer) *peer.Config {
 			// not signed with its key.  We could verify against their key, but
 			// since the reference client is currently unwilling to support
 			// other implementations' alert messages, we will not relay theirs.
-			OnPing: sp.OnPing,
 			OnAlert: nil,
 		},
 		NewestBlock:       sp.newestBlock,
@@ -2103,6 +2103,9 @@ out:
 		case blocksMsg := <-s.relayBlocks:
 			s.handleRelayBlocks(state, blocksMsg)
 
+		case pingMsg := <-s.pings:
+			s.handlePing(pingMsg)
+
 		case minedBlockMsg := <-s.minedBlock:
 			s.handleMinedBlock(minedBlockMsg)
 			// Message to broadcast to all connected peers except those
@@ -2143,6 +2146,7 @@ cleanup:
 		case <-s.peerHeightsUpdate:
 		case <-s.relayInv:
 		case <-s.relayBlocks:
+		case <-s.pings:
 		case <-s.broadcast:
 		case <-s.query:
 		default:
@@ -2596,6 +2600,7 @@ func NewServer(chainParams *model.BitcoinParams, ts *util.MedianTime, interrupt 
 		query:                make(chan interface{}),
 		relayInv:             make(chan relayMsg, cfg.P2PNet.MaxPeers),
 		relayBlocks:          make(chan relayBlocksMsg, cfg.P2PNet.MaxPeers),
+		pings:     		      make(chan *PingMsg, cfg.P2PNet.MaxPeers),
 		minedBlock:           make(chan minedBlockMsg),
 		broadcast:            make(chan broadcastMsg, cfg.P2PNet.MaxPeers),
 		quit:                 make(chan struct{}),

--- a/net/server/server.go
+++ b/net/server/server.go
@@ -1608,7 +1608,7 @@ func (s *Server) loadBannedInfo() error {
 
 func (s *Server) handleRelayBlocks(state *peerState, msg relayBlocksMsg) {
 	state.forAllPeers(func(sp *serverPeer) {
-		if !sp.Connected() {
+		if !sp.Connected() || !sp.VerAckReceived() {
 			return
 		}
 
@@ -1633,7 +1633,7 @@ func (s *Server) handlePing(msg *PingMsg) {
 // known to have it.  It is invoked from the peerHandler goroutine.
 func (s *Server) handleRelayInvMsg(state *peerState, msg relayMsg) {
 	state.forAllPeers(func(sp *serverPeer) {
-		if !sp.Connected() {
+		if !sp.Connected() || !sp.VerAckReceived() {
 			return
 		}
 

--- a/net/server/server_test.go
+++ b/net/server/server_test.go
@@ -1142,7 +1142,7 @@ func TestInitListeners(t *testing.T) {
 
 	// port is occupied
 	listeners2, _, err := initListeners(s.addrManager, listenAddrs, services)
-	assert.Nil(t, err)
+	assert.NotNil(t, err)
 	assert.Equal(t, 0, len(listeners2))
 
 	for _, listener := range listeners {

--- a/net/server/txrelayer.go
+++ b/net/server/txrelayer.go
@@ -1,0 +1,77 @@
+package server
+
+import (
+    "github.com/copernet/copernicus/logic/lmempool"
+    "github.com/copernet/copernicus/model/mempool"
+    "github.com/copernet/copernicus/model/tx"
+    "github.com/copernet/copernicus/util"
+    "sync"
+    "time"
+)
+
+type txCacheItem struct {
+    txn *tx.Tx
+    cacheTime time.Time
+}
+
+type TxRelayer struct {
+    lck sync.RWMutex
+
+    cache map[util.Hash]*txCacheItem
+
+    lastCompactTime time.Time
+}
+
+func (txr *TxRelayer) Cache(txId *util.Hash, txn *tx.Tx) {
+    txr.lck.Lock()
+    defer txr.lck.Unlock()
+
+    if txn == nil {
+        txe := lmempool.FindTxInMempool(*txId)
+        if txe == nil {
+            return
+        }
+        txn = txe.Tx
+    }
+
+    txr.cache[*txId] = &txCacheItem{txn: txn, cacheTime: time.Now()}
+
+    txr.limitCache()
+}
+
+func (txr *TxRelayer) TxToRelay(txId *util.Hash) *tx.Tx {
+    txr.lck.RLock()
+    defer txr.lck.RUnlock()
+
+    if v, exists := txr.cache[*txId]; exists {
+        return v.txn
+    }
+
+    if txe := mempool.GetInstance().FindTx(*txId); txe != nil {
+        return txe.Tx
+    }
+
+    return nil
+}
+
+func (txr *TxRelayer) limitCache() {
+    if time.Now().Before(txr.lastCompactTime.Add(time.Minute * 15)) {
+        return
+    }
+
+    _15minsAgo := time.Now().Add(time.Minute * -15)
+    for k, v := range txr.cache {
+        if  v.cacheTime.Before(_15minsAgo) {
+            delete(txr.cache, k)
+        }
+    }
+
+    txr.lastCompactTime = time.Now()
+}
+
+func NewTxRelayer() *TxRelayer {
+    return &TxRelayer{
+        cache: make(map[util.Hash]*txCacheItem),
+        lastCompactTime: time.Now(),
+    }
+}

--- a/net/syncmanager/syncmanager.go
+++ b/net/syncmanager/syncmanager.go
@@ -888,15 +888,11 @@ func (sm *SyncManager) handleHeadersMsg(hmsg *headersMsg) {
 		return
 	}
 
-	//also parallel fetch blocks from syncPeer, when do not have many peers
-	if len(sm.peerStates) <= 2 {
-		sm.fetchHeaderBlocks(peer)
-		return
-	}
-	// syncPeer has no more work to download headers, let it start download blocks
-	if !hasMore {
-		sm.fetchHeaderBlocks(peer)
-		return
+	// syncPeer has no more work to download headers, start download blocks
+	if !hasMore && lchain.IsInitialBlockDownload() {
+		for peer := range sm.peerStates {
+			sm.fetchHeaderBlocks(peer)
+		}
 	}
 }
 

--- a/net/syncmanager/syncmanager.go
+++ b/net/syncmanager/syncmanager.go
@@ -906,6 +906,10 @@ func (sm *SyncManager) handleInvMsg(imsg *invMsg) {
 		}
 	}
 
+	if lastBlock != -1 {
+		peer.CheckRevertToInv(&invVects[lastBlock].Hash)
+	}
+
 	// If this inv contains a block announcement, and this isn't coming from
 	// our current sync peer or we're current, then update the last
 	// announced block for this peer. We'll use this information later to

--- a/net/syncmanager/syncmanager.go
+++ b/net/syncmanager/syncmanager.go
@@ -1267,16 +1267,6 @@ func (sm *SyncManager) QueueMessgePool(pool *wire.MsgMemPool, peer *peer.Peer, d
 	sm.processBusinessChan <- &poolMsg{pool, peer, done}
 }
 
-func (sm *SyncManager) QueueGetData(getdata *wire.MsgGetData, peer *peer.Peer, done chan<- struct{}) {
-	// Don't accept more blocks if we're shutting down.
-	if atomic.LoadInt32(&sm.shutdown) != 0 {
-		done <- struct{}{}
-		return
-	}
-
-	sm.processBusinessChan <- getdataMsg{getdata, peer, done}
-}
-
 func (sm *SyncManager) QueueGetBlocks(getblocks *wire.MsgGetBlocks, peer *peer.Peer, done chan<- struct{}) {
 	// Don't accept more blocks if we're shutting down.
 	if atomic.LoadInt32(&sm.shutdown) != 0 {

--- a/net/syncmanager/syncmanager.go
+++ b/net/syncmanager/syncmanager.go
@@ -1037,7 +1037,7 @@ func (sm *SyncManager) handleInvMsg(imsg *invMsg) {
 	}
 
 	if lastBlock != -1 {
-		peer.CheckRevertToInv(&invVects[lastBlock].Hash)
+		peer.CheckRevertToInv(&invVects[lastBlock].Hash, true)
 	}
 
 	// If this inv contains a block announcement, and this isn't coming from

--- a/net/syncmanager/syncmanager.go
+++ b/net/syncmanager/syncmanager.go
@@ -591,6 +591,12 @@ func (sm *SyncManager) handleBlockMsg(bmsg *blockMsg) {
 		}
 	}
 
+	// Process all blocks from whitelisted peers, even if not requested,
+	// unless we're still syncing with the network. Such an unrequested
+	// block may still be processed, subject to the conditions in AcceptBlock().
+	fromWhitelist := peer.IsWhitelisted() && !lchain.IsInitialBlockDownload()
+	_, requested := sm.requestedBlocks[blockHash]
+
 	// Remove block from request maps. Either chain will know about it and
 	// so we shouldn't have any more instances of trying to fetch it, or we
 	// will fail the insert and thus we'll retry next time we get an inv.

--- a/net/syncmanager/syncmanager.go
+++ b/net/syncmanager/syncmanager.go
@@ -61,7 +61,7 @@ const (
 	MAX_UNCONNECTING_HEADERS = 10
 
 	// fetchInterval is the interval to fetchHeaderBlocks for all peer
-	fetchInterval = 500 * time.Millisecond
+	fetchInterval = 1 * time.Second
 
 	// BLOCK_STALLING_TIMEOUT in microsecond during which a peer must stall block
 	// download progress before being disconnected
@@ -631,8 +631,7 @@ func (sm *SyncManager) handleBlockMsg(bmsg *blockMsg) {
 	if blkHashUpdate != nil && heightUpdate != 0 {
 		peer.UpdateLastBlockHeight(heightUpdate)
 		if sm.current() && peer == sm.syncPeer {
-			go sm.peerNotifier.UpdatePeerHeights(blkHashUpdate, heightUpdate,
-				peer)
+			go sm.peerNotifier.UpdatePeerHeights(blkHashUpdate, heightUpdate, peer)
 			log.Debug("request mempool in handleBlockMsg")
 			peer.RequestMemPool()
 		}

--- a/net/syncmanager/syncmanager.go
+++ b/net/syncmanager/syncmanager.go
@@ -1483,7 +1483,7 @@ func (sm *SyncManager) Pause() chan<- struct{} {
 }
 
 func (sm *SyncManager) misbehaving(peerAddr string, banScore uint32, reason string) {
-	sm.AddBanScoreCallBack(peerAddr, 0, banScore, reason)
+	sm.AddBanScoreCallBack(peerAddr, banScore, 0, reason)
 }
 
 // New constructs a new SyncManager. Use Start to begin processing asynchronous

--- a/net/syncmanager/syncmanager.go
+++ b/net/syncmanager/syncmanager.go
@@ -677,7 +677,16 @@ func (sm *SyncManager) syncPoints(peer *peer.Peer) (pindexWalk, pindexBestKnownB
 	isIBDSyncing := sm.syncPeer != nil && lchain.IsInitialBlockDownload()
 
 	if isIBDSyncing {
-		return gChain.Tip(), lastAccouncedBlock(sm.syncPeer)
+		idx := lastAccouncedBlock(sm.syncPeer)
+		if idx == nil {
+			pindexStart := gChain.GetIndexBestHeader()
+			if pindexStart.Prev != nil {
+				pindexStart = pindexStart.Prev
+			}
+			locator := gChain.GetLocator(pindexStart)
+			sm.syncPeer.PushGetHeadersMsg(*locator, &zeroHash)
+		}
+		return gChain.Tip(), idx
 	}
 
 	if pindexBestKnownBlock = lastAccouncedBlock(peer); pindexBestKnownBlock != nil {

--- a/net/syncmanager/syncmanager.go
+++ b/net/syncmanager/syncmanager.go
@@ -382,6 +382,21 @@ func (sm *SyncManager) handleNewPeerMsg(peer *peer.Peer) {
 		requestedBlocks: make(map[util.Hash]struct{}),
 	}
 
+	if !lchain.IsInitialBlockDownload() {
+		gChain := chain.GetInstance()
+		pindexBestHeader := gChain.GetIndexBestHeader()
+		if pindexBestHeader == nil {
+			pindexBestHeader = gChain.Tip()
+			gChain.SetIndexBestHeader(pindexBestHeader)
+		}
+		pindexStart := pindexBestHeader
+		if pindexStart.Prev != nil {
+			pindexStart = pindexStart.Prev
+		}
+		locator := gChain.GetLocator(pindexStart)
+		peer.PushGetHeadersMsg(*locator, &zeroHash)
+	}
+
 	// Start syncing by choosing the best candidate if needed.
 	if isSyncCandidate && sm.syncPeer == nil {
 		sm.startSync()

--- a/net/syncmanager/syncmanager.go
+++ b/net/syncmanager/syncmanager.go
@@ -6,6 +6,7 @@ package syncmanager
 
 import (
 	"container/list"
+	"github.com/copernet/copernicus/model/pow"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -21,7 +22,6 @@ import (
 	"github.com/copernet/copernicus/model/chain"
 	"github.com/copernet/copernicus/model/mempool"
 	"github.com/copernet/copernicus/model/outpoint"
-	"github.com/copernet/copernicus/model/pow"
 	"github.com/copernet/copernicus/model/tx"
 	"github.com/copernet/copernicus/model/utxo"
 	"github.com/copernet/copernicus/net/wire"
@@ -698,15 +698,15 @@ func (sm *SyncManager) fetchHeaderBlocks(peer *peer.Peer) {
 			return
 		}
 
-		minWorkSum := pow.HashToBig(&model.ActiveNetParams.MinimumChainWork)
-		if pindexBestKnownBlock.ChainWork.Cmp(&(gChain.Tip().ChainWork)) == -1 ||
-			pindexBestKnownBlock.ChainWork.Cmp(minWorkSum) == -1 {
-			log.Info("peer(%d) ChainWork less than us, hash nothing interesting",
-				peer.ID())
-			return
-		}
-
 		pindexWalk = gChain.FindFork(pindexBestKnownBlock)
+	}
+
+	minWorkSum := pow.MiniChainWork()
+	if pindexBestKnownBlock.ChainWork.Cmp(&(gChain.Tip().ChainWork)) == -1 ||
+		pindexBestKnownBlock.ChainWork.Cmp(&minWorkSum) == -1 {
+		log.Info("peer(%d) ChainWork less than us, hash nothing interesting",
+			peer.ID())
+		return
 	}
 
 	vToFetch := list.New()

--- a/net/syncmanager/syncmanager.go
+++ b/net/syncmanager/syncmanager.go
@@ -1001,11 +1001,12 @@ func (sm *SyncManager) handleInvMsg(imsg *invMsg) {
 			// Request the block if there is not already a pending
 			// request.
 			if _, exists := sm.requestedBlocks[iv.Hash]; !exists {
-				sm.requestedBlocks[iv.Hash] = struct{}{}
-				sm.limitMap(sm.requestedBlocks, maxRequestedBlocks)
-				state.requestedBlocks[iv.Hash] = struct{}{}
-				gdmsg.AddInvVect(iv)
-				numRequested++
+				pindexStart := activeChain.Tip()
+				locator := activeChain.GetLocator(pindexStart)
+				log.Info("Syncing to block height %d from peer %v",
+					peer.LastBlock(), peer.Addr())
+
+				peer.PushGetHeadersMsg(*locator, &iv.Hash)
 			}
 
 		case wire.InvTypeTx:

--- a/net/syncmanager/syncmanager.go
+++ b/net/syncmanager/syncmanager.go
@@ -1207,11 +1207,7 @@ out:
 					msg.peer.Cfg.Listeners.OnGetBlocks(msg.peer, msg.getblocks)
 				}
 				msg.reply <- struct{}{}
-			case pingMsg:
-				if msg.peer.Cfg.Listeners.OnPing != nil {
-					msg.peer.Cfg.Listeners.OnPing(msg.peer, msg.ping)
-				}
-				msg.reply <- struct{}{}
+
 			case *donePeerMsg:
 				sm.handleDonePeerMsg(msg.peer)
 

--- a/net/syncmanager/syncmanager.go
+++ b/net/syncmanager/syncmanager.go
@@ -712,9 +712,14 @@ func (sm *SyncManager) fetchHeaderBlocks(peer *peer.Peer) {
 	}
 
 	minWorkSum := pow.MiniChainWork()
-	if pindexBestKnownBlock.ChainWork.Cmp(&(gChain.Tip().ChainWork)) == -1 ||
-		pindexBestKnownBlock.ChainWork.Cmp(&minWorkSum) == -1 {
-		log.Info("peer(%d) ChainWork less than us, hash nothing interesting", peer.ID())
+	if pindexBestKnownBlock.ChainWork.Cmp(&minWorkSum) == -1 {
+		log.Info("peer(%d) ChainWork less than minChainWork, wait header download", peer.ID())
+		return
+	}
+
+	tipWork := gChain.Tip().ChainWork
+	if pindexBestKnownBlock.ChainWork.Cmp(&tipWork) == -1 {
+		log.Info("peer(%d) ChainWork less than tipWork, has nothing interesting", peer.ID())
 		return
 	}
 

--- a/net/syncmanager/syncmanager.go
+++ b/net/syncmanager/syncmanager.go
@@ -692,16 +692,7 @@ func (sm *SyncManager) syncPoints(peer *peer.Peer) (pindexWalk, pindexBestKnownB
 	isIBDSyncing := sm.syncPeer != nil && lchain.IsInitialBlockDownload()
 
 	if isIBDSyncing {
-		idx := lastAccouncedBlock(sm.syncPeer)
-		if idx == nil {
-			pindexStart := gChain.GetIndexBestHeader()
-			if pindexStart.Prev != nil {
-				pindexStart = pindexStart.Prev
-			}
-			locator := gChain.GetLocator(pindexStart)
-			sm.syncPeer.PushGetHeadersMsg(*locator, &zeroHash)
-		}
-		return gChain.Tip(), idx
+		return gChain.Tip(), gChain.GetIndexBestHeader()
 	}
 
 	if pindexBestKnownBlock = lastAccouncedBlock(peer); pindexBestKnownBlock != nil {

--- a/net/syncmanager/syncmanager.go
+++ b/net/syncmanager/syncmanager.go
@@ -930,6 +930,9 @@ func (sm *SyncManager) handleHeadersMsg(hmsg *headersMsg) {
 			log.Info("Large reorg, won't direct fetch to %s (%d)",
 				pindexLast.GetBlockHash().String(),
 				pindexLast.Height)
+
+			sm.fetchHeaderBlocks(peer)
+			return
 		} else {
 			// Download as much as possible, from earliest to latest.
 			gdmsg := wire.NewMsgGetData()

--- a/net/syncmanager/syncmanager_test.go
+++ b/net/syncmanager/syncmanager_test.go
@@ -253,20 +253,6 @@ func TestMessgePool(t *testing.T) {
 	sm.Stop()
 }
 
-func TestGetData(t *testing.T) {
-	gd := wire.NewMsgGetData()
-	sm, dir, err := makeSyncManager()
-	if err != nil {
-		t.Fatalf("construct syncmanager failed :%v\n", err)
-	}
-	defer os.RemoveAll(dir)
-	config := peer.Config{}
-	in := peer.NewInboundPeer(&config, false)
-	done := make(chan struct{})
-	sm.Start()
-	sm.QueueGetData(gd, in, done)
-}
-
 func TestGetBlocks(t *testing.T) {
 	blk := wire.NewMsgGetBlocks(&util.HashZero)
 	sm, dir, err := makeSyncManager()

--- a/net/syncmanager/syncmanager_test.go
+++ b/net/syncmanager/syncmanager_test.go
@@ -277,6 +277,7 @@ func TestQueueHeaders(t *testing.T) {
 	in := peer.NewInboundPeer(&config, false)
 	sm.Start()
 	sm.QueueHeaders(hdr, in)
+	sm.Stop()
 }
 
 func TestPause(t *testing.T) {
@@ -287,6 +288,7 @@ func TestPause(t *testing.T) {
 	defer os.RemoveAll(dir)
 	sm.Start()
 	sm.Pause() <- struct{}{}
+	sm.Stop()
 }
 
 func createBlkIdx() *blockindex.BlockIndex {
@@ -359,6 +361,7 @@ func TestSyncManager_handleBlockchainNotification(t *testing.T) {
 		}
 		sm.handleBlockchainNotification(notification)
 	}
+	sm.Stop()
 }
 
 func TestSyncManager_limitMap(t *testing.T) {
@@ -377,6 +380,7 @@ func TestSyncManager_limitMap(t *testing.T) {
 	assert.Equal(t, len(mp), 2)
 	sm.limitMap(mp, 2)
 	assert.Equal(t, len(mp), 1)
+	sm.Stop()
 }
 
 func TestSyncManager_findNextHeaderCheckpoint(t *testing.T) {
@@ -420,6 +424,7 @@ func TestSyncManager_findNextHeaderCheckpoint(t *testing.T) {
 	if ckPoint1 != nil {
 		t.Errorf("find next header checkPoint failed, ckPoint1:%v", ckPoint1)
 	}
+	sm.Stop()
 }
 
 type conn struct {
@@ -580,6 +585,7 @@ func TestSyncManager_isSyncCandidate(t *testing.T) {
 		//close connection
 		inPeer.Disconnect()
 	}
+	sm.Stop()
 }
 
 func TestSyncManager_alreadyHave(t *testing.T) {
@@ -598,6 +604,7 @@ func TestSyncManager_alreadyHave(t *testing.T) {
 	sm.rejectedTxns = rejectedTxns
 	ret = sm.alreadyHave(hash1)
 	assert.Equal(t, ret, true)
+	sm.Stop()
 }
 
 func TestSyncManager_handleInvMsg(t *testing.T) {
@@ -650,6 +657,7 @@ func TestSyncManager_handleInvMsg(t *testing.T) {
 	}
 
 	sm.handleInvMsg(invMsg2)
+	sm.Stop()
 }
 
 func ProcessBlockHeaderReturnErr(headerList []*block.BlockHeader, lastIndex *blockindex.BlockIndex) error {
@@ -723,6 +731,7 @@ func TestSyncManager_handleHeadersMsg(t *testing.T) {
 	sm.handleHeadersMsg(hmsg3)
 
 	sm.handleHeadersMsg(hmsg3)
+	sm.Stop()
 }
 
 func TestSyncManager_fetchHeaderBlocks(t *testing.T) {
@@ -753,6 +762,7 @@ func TestSyncManager_fetchHeaderBlocks(t *testing.T) {
 	sm.requestedBlocks = make(map[util.Hash]*peer.Peer)
 	sm.syncPeer = inpeer
 	sm.fetchHeaderBlocks(inpeer)
+	sm.Stop()
 }
 
 func TestSyncManager_updateTxRequestState(t *testing.T) {
@@ -773,10 +783,11 @@ func TestSyncManager_updateTxRequestState(t *testing.T) {
 	rejectedTxns = append(rejectedTxns, *hash1)
 
 	sm.updateTxRequestState(syncState, *hash1, rejectedTxns)
+	sm.Stop()
 }
 
 func TestSyncManager_fetchMissingTx(t *testing.T) {
-	_, dir, err := makeSyncManager()
+	sm, dir, err := makeSyncManager()
 	if err != nil {
 		t.Fatalf("construct syncmanager failed :%v\n", err)
 	}
@@ -790,6 +801,7 @@ func TestSyncManager_fetchMissingTx(t *testing.T) {
 	missTxs = append(missTxs, *hash2)
 
 	fetchMissingTx(missTxs, inpeer)
+	sm.Stop()
 }
 
 func TestSyncManager_handleBlockMsg(t *testing.T) {
@@ -845,6 +857,7 @@ func TestSyncManager_handleBlockMsg(t *testing.T) {
 	sm.handleBlockMsg(bmsg2)
 
 	sm.handleBlockMsg(bmsg2)
+	sm.Stop()
 }
 
 func ProcessTxAcceptAll(txn *tx.Tx, recentRejects map[util.Hash]struct{}, nodeID int64) ([]*tx.Tx, []util.Hash, []util.Hash, error) {
@@ -888,6 +901,7 @@ func TestSyncManager_handleTxMsg(t *testing.T) {
 	mempool.GetInstance().RemoveOrphansByTag(int64(inpeer.ID()))
 	sm.ProcessTransactionCallBack = service.ProcessTransaction
 	assert.NotPanics(t, func() { sm.handleTxMsg(tmsg) })
+	sm.Stop()
 }
 
 func generateBlocks(t *testing.T, generate int, maxTries uint64, verify bool) ([]*block.Block, error) {
@@ -998,8 +1012,6 @@ func initTestEnv() func() {
 	cleanup := func() {
 		os.RemoveAll(unitTestDataDirPath)
 		log.Debug("cleanup test dir: %s", unitTestDataDirPath)
-		gChain := chain.GetInstance()
-		*gChain = *chain.NewChain()
 	}
 
 	return cleanup
@@ -1075,6 +1087,7 @@ func TestSyncManager_NewPeer(t *testing.T) {
 	// old sync(2) < self(1), is not current
 	// syncPeer not change
 	assert.Equal(t, outPeer, sm.syncPeer)
+	sm.Stop()
 }
 
 func TestSyncManager_Current(t *testing.T) {
@@ -1096,6 +1109,7 @@ func TestSyncManager_Current(t *testing.T) {
 
 	// time of tip is now
 	assert.True(t, sm.current())
+	sm.Stop()
 }
 
 func TestSyncManager_DonePeer(t *testing.T) {
@@ -1115,4 +1129,5 @@ func TestSyncManager_DonePeer(t *testing.T) {
 
 	sm.syncPeer = inpeer
 	sm.handleDonePeerMsg(inpeer)
+	sm.Stop()
 }

--- a/net/syncmanager/syncmanager_test.go
+++ b/net/syncmanager/syncmanager_test.go
@@ -1056,6 +1056,7 @@ func TestSyncManager_NewPeer(t *testing.T) {
 		UserAgentVersion:  "1.0",
 		UserAgentComments: []string{"comment"},
 		ChainParams:       &model.MainNetParams,
+		ProtocolVersion:   wire.SendHeadersVersion,
 		Services:          wire.SFNodeNetwork,
 	}
 	inConn, outConn := pipe(
@@ -1074,6 +1075,7 @@ func TestSyncManager_NewPeer(t *testing.T) {
 
 	outMsgChan := make(chan *peer.PeerMessage)
 	outPeer.AssociateConnection(outConn, outMsgChan, func(*peer.Peer) {})
+	outPeer.SetAckReceived(true)
 
 	sm.syncPeer = inPeer
 	outPeer.UpdateLastBlockHeight(2)

--- a/net/syncmanager/syncmanager_test.go
+++ b/net/syncmanager/syncmanager_test.go
@@ -731,7 +731,6 @@ func TestSyncManager_fetchHeaderBlocks(t *testing.T) {
 		t.Fatalf("construct syncmanager failed :%v\n", err)
 	}
 	defer os.RemoveAll(dir)
-	sm.fetchHeaderBlocks(nil)
 
 	hash1 := util.HashFromString("00000000000001bcd6b635a1249dfbe76c0d001592a7219a36cd9bbd002c7238")
 	inpeer := peer.NewInboundPeer(peer1Cfg, false)

--- a/net/syncmanager/syncmanager_test.go
+++ b/net/syncmanager/syncmanager_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/copernet/copernicus/logic/lchain"
 	"github.com/copernet/copernicus/logic/lmerkleroot"
 	"github.com/copernet/copernicus/model"
-	"github.com/copernet/copernicus/model/bitcointime"
 	"github.com/copernet/copernicus/model/block"
 	"github.com/copernet/copernicus/model/blockindex"
 	"github.com/copernet/copernicus/model/chain"
@@ -755,7 +754,6 @@ func TestSyncManager_fetchHeaderBlocks(t *testing.T) {
 	p.SetAckReceived(true)
 
 	sm.fetchHeaderBlocks(p)
->>>>>>> add some unit test of syncmanager, now coverage is at 80%;
 
 	invVect1 := wire.NewInvVect(wire.InvTypeTx, hash1)
 	msgInv := wire.NewMsgInv()
@@ -1182,7 +1180,7 @@ func TestSyncManager_startsync_alreadysync(t *testing.T) {
 	})
 	assert.Nil(t, err)
 
-	inpeer := peer.NewInboundPeer(peer1Cfg)
+	inpeer := peer.NewInboundPeer(peer1Cfg, false)
 	sm.syncPeer = inpeer
 	sm.startSync()
 
@@ -1209,7 +1207,7 @@ func TestSyncManager_isSyncCandidate_regress(t *testing.T) {
 	defer os.RemoveAll(dir)
 	sm.chainParams = &model.RegressionNetParams
 
-	p, _ := peer.NewOutboundPeer(peer1Cfg, "10.0.0.1:123")
+	p, _ := peer.NewOutboundPeer(peer1Cfg, "10.0.0.1:123", false)
 
 	ret := sm.isSyncCandidate(p)
 	sm.Stop()
@@ -1310,7 +1308,7 @@ func TestSyncManager_lastAccouncedBlock(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	p, _ := peer.NewOutboundPeer(peer1Cfg, "10.0.0.1:123")
+	p, _ := peer.NewOutboundPeer(peer1Cfg, "10.0.0.1:123", false)
 	idx := lastAccouncedBlock(p)
 	assert.Nil(t, idx)
 
@@ -1364,7 +1362,7 @@ func TestSyncManager_fetchBlocks(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	hash1 := util.HashFromString("00000000000001bcd6b635a1249dfbe76c0d001592a7219a36cd9bbd002c7238")
-	p, _ := peer.NewOutboundPeer(peer1Cfg, "127.0.0.1:123")
+	p, _ := peer.NewOutboundPeer(peer1Cfg, "127.0.0.1:123", false)
 
 	requestedTxns := make(map[util.Hash]struct{})
 	requestedBlocks := make(map[util.Hash]struct{})
@@ -1404,7 +1402,7 @@ func TestSyncManager_fetchBlocks(t *testing.T) {
 
 	sm.clearSyncPeerState(p)
 
-	p2, _ := peer.NewOutboundPeer(peer1Cfg, "127.0.0.1:1234")
+	p2, _ := peer.NewOutboundPeer(peer1Cfg, "127.0.0.1:1234", false)
 	sm.fetchHeadersToConnect(p, syncState)
 	sm.fetchHeadersToConnect(p2, syncState)
 	headerMsg := wire.NewMsgHeaders()

--- a/net/syncmanager/syncmanager_test.go
+++ b/net/syncmanager/syncmanager_test.go
@@ -750,7 +750,7 @@ func TestSyncManager_fetchHeaderBlocks(t *testing.T) {
 	}
 
 	sm.peerStates[inpeer] = syncState
-	sm.requestedBlocks = make(map[util.Hash]struct{})
+	sm.requestedBlocks = make(map[util.Hash]*peer.Peer)
 	sm.syncPeer = inpeer
 	sm.fetchHeaderBlocks(inpeer)
 }

--- a/net/wire/msgheaders.go
+++ b/net/wire/msgheaders.go
@@ -136,6 +136,18 @@ func (msg *MsgHeaders) MaxPayloadLength(pver uint32) uint64 {
 		MaxBlockHeadersPerMsg)
 }
 
+func (msg *MsgHeaders) IsContinuousHeaders() bool {
+	var prev util.Hash
+	for _, blockHeader := range msg.Headers {
+		if !prev.IsNull() && !prev.IsEqual(&blockHeader.HashPrevBlock) {
+			return false
+		}
+
+		prev = blockHeader.GetHash()
+	}
+	return true
+}
+
 // NewMsgHeaders returns a new bitcoin headers message that conforms to the
 // Message interface.  See MsgHeaders for details.
 func NewMsgHeaders() *MsgHeaders {

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -1031,24 +1031,24 @@ func (p *Peer) PushGetBlocksMsg(locator chain.BlockLocator, stopHash *util.Hash)
 func (p *Peer) PushGetHeadersMsg(locator chain.BlockLocator, stopHash *util.Hash) error {
 	// Extract the begin hash from the block locator, if one was specified,
 	// to use for filtering duplicate getheaders requests.
-	var beginHash *util.Hash
+	//var beginHash *util.Hash
 	blkHashs := locator.GetBlockHashList()
-	if len(blkHashs) > 0 {
-		beginHash = &blkHashs[0]
-	}
+	//if len(blkHashs) > 0 {
+	//	beginHash = &blkHashs[0]
+	//}
 
 	// Filter duplicate getheaders requests.
-	p.prevGetHdrsMtx.Lock()
-	isDuplicate := p.prevGetHdrsStop != nil && p.prevGetHdrsBegin != nil &&
-		beginHash != nil && stopHash.IsEqual(p.prevGetHdrsStop) &&
-		beginHash.IsEqual(p.prevGetHdrsBegin)
-	p.prevGetHdrsMtx.Unlock()
+	//p.prevGetHdrsMtx.Lock()
+	//isDuplicate := p.prevGetHdrsStop != nil && p.prevGetHdrsBegin != nil &&
+	//	beginHash != nil && stopHash.IsEqual(p.prevGetHdrsStop) &&
+	//	beginHash.IsEqual(p.prevGetHdrsBegin)
+	//p.prevGetHdrsMtx.Unlock()
 
-	if isDuplicate {
-		log.Trace("Filtering duplicate [getheaders] with begin hash %v",
-			beginHash)
-		return nil
-	}
+	//if isDuplicate {
+	//	log.Trace("Filtering duplicate [getheaders] with begin hash %v",
+	//		beginHash)
+	//	//return nil
+	//}
 
 	// Construct the getheaders request and queue it to be sent.
 	msg := wire.NewMsgGetHeaders()
@@ -1064,10 +1064,10 @@ func (p *Peer) PushGetHeadersMsg(locator chain.BlockLocator, stopHash *util.Hash
 
 	// Update the previous getheaders request information for filtering
 	// duplicates.
-	p.prevGetHdrsMtx.Lock()
-	p.prevGetHdrsBegin = beginHash
-	p.prevGetHdrsStop = stopHash
-	p.prevGetHdrsMtx.Unlock()
+	//p.prevGetHdrsMtx.Lock()
+	//p.prevGetHdrsBegin = beginHash
+	//p.prevGetHdrsStop = stopHash
+	//p.prevGetHdrsMtx.Unlock()
 	return nil
 }
 

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -982,24 +982,7 @@ func (p *Peer) PushAddrMsg(addresses []*wire.NetAddress) ([]*wire.NetAddress, er
 func (p *Peer) PushGetBlocksMsg(locator chain.BlockLocator, stopHash *util.Hash) error {
 	// Extract the begin hash from the block locator, if one was specified,
 	// to use for filtering duplicate getblocks requests.
-	var beginHash *util.Hash
 	blkHashs := locator.GetBlockHashList()
-	if len(blkHashs) > 0 {
-		beginHash = &blkHashs[0]
-	}
-
-	// Filter duplicate getblocks requests.
-	// p.prevGetBlocksMtx.Lock()
-	// isDuplicate := p.prevGetBlocksStop != nil && p.prevGetBlocksBegin != nil &&
-	// 	beginHash != nil && stopHash.IsEqual(p.prevGetBlocksStop) &&
-	// 	beginHash.IsEqual(p.prevGetBlocksBegin)
-	// p.prevGetBlocksMtx.Unlock()
-
-	// if isDuplicate {
-	// 	log.Trace("Filtering duplicate [getblocks] with begin "+
-	// 		"hash %v, stop hash %v", beginHash, stopHash)
-	// 	return nil
-	// }
 
 	// Construct the getblocks request and queue it to be sent.
 	msg := wire.NewMsgGetBlocks(stopHash)
@@ -1011,12 +994,6 @@ func (p *Peer) PushGetBlocksMsg(locator chain.BlockLocator, stopHash *util.Hash)
 	}
 	p.QueueMessage(msg, nil)
 	log.Trace("send Blocks Msg, Request locator to stop hash for these blocks hash ...")
-	// Update the previous getblocks request information for filtering
-	// duplicates.
-	p.prevGetBlocksMtx.Lock()
-	p.prevGetBlocksBegin = beginHash
-	p.prevGetBlocksStop = stopHash
-	p.prevGetBlocksMtx.Unlock()
 	return nil
 }
 
@@ -1027,24 +1004,7 @@ func (p *Peer) PushGetBlocksMsg(locator chain.BlockLocator, stopHash *util.Hash)
 func (p *Peer) PushGetHeadersMsg(locator chain.BlockLocator, stopHash *util.Hash) error {
 	// Extract the begin hash from the block locator, if one was specified,
 	// to use for filtering duplicate getheaders requests.
-	//var beginHash *util.Hash
 	blkHashs := locator.GetBlockHashList()
-	//if len(blkHashs) > 0 {
-	//	beginHash = &blkHashs[0]
-	//}
-
-	// Filter duplicate getheaders requests.
-	//p.prevGetHdrsMtx.Lock()
-	//isDuplicate := p.prevGetHdrsStop != nil && p.prevGetHdrsBegin != nil &&
-	//	beginHash != nil && stopHash.IsEqual(p.prevGetHdrsStop) &&
-	//	beginHash.IsEqual(p.prevGetHdrsBegin)
-	//p.prevGetHdrsMtx.Unlock()
-
-	//if isDuplicate {
-	//	log.Trace("Filtering duplicate [getheaders] with begin hash %v",
-	//		beginHash)
-	//	//return nil
-	//}
 
 	// Construct the getheaders request and queue it to be sent.
 	msg := wire.NewMsgGetHeaders()
@@ -1058,12 +1018,6 @@ func (p *Peer) PushGetHeadersMsg(locator chain.BlockLocator, stopHash *util.Hash
 	}
 	p.QueueMessage(msg, nil)
 
-	// Update the previous getheaders request information for filtering
-	// duplicates.
-	//p.prevGetHdrsMtx.Lock()
-	//p.prevGetHdrsBegin = beginHash
-	//p.prevGetHdrsStop = stopHash
-	//p.prevGetHdrsMtx.Unlock()
 	return nil
 }
 

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -80,7 +80,7 @@ const (
 	maxBlocksToAnnounce = 8
 
 	// when peer is neer to tip, set its revertToInv to false back
-	REVERT_TO_INV_DIFF = 7
+	REVERT_TO_INV_DIFF = 8
 )
 
 var (

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -79,7 +79,7 @@ const (
 	// increase the num in case cut out inv
 	maxBlocksToAnnounce = 8
 
-	// when peer is neer to tip, set its revertToInv to false back
+	// REVERT_TO_INV_DIFF when peer is neer to tip, set its revertToInv to false back
 	REVERT_TO_INV_DIFF = 8
 )
 
@@ -462,7 +462,7 @@ type Peer struct {
 	advertisedProtoVer   uint32 // protocol version advertised by remote
 	protocolVersion      uint32 // negotiated protocol version
 	sendHeadersPreferred bool   // peer sent a sendheaders message
-	revertToInv			 bool //whether to revert to inv mode for a prefer-header-node
+	revertToInv          bool   //whether to revert to inv mode for a prefer-header-node
 	verAckReceived       bool
 	isWhitelisted        bool
 
@@ -493,8 +493,8 @@ type Peer struct {
 	sendQueue         chan outMsg
 	sendDoneQueue     chan struct{}
 	outputInvChan     chan *wire.InvVect
-	outputHeaderChan     chan *block.BlockHeader
-	outputHeadersChan     chan []*block.BlockHeader
+	outputHeaderChan  chan *block.BlockHeader
+	outputHeadersChan chan []*block.BlockHeader
 	inQuit            chan struct{}
 	queueQuit         chan struct{}
 	outQuit           chan struct{}
@@ -1739,17 +1739,11 @@ cleanup:
 	log.Trace("Peer queue handler done for %s", p)
 }
 
-func (p *Peer) AddHeadersToSendQ(headers []*block.BlockHeader)  {
+func (p *Peer) AddHeadersToSendQ(headers []*block.BlockHeader) {
 	headerSendQueue := list.New()
 
-	for _, header := range headers{
+	for _, header := range headers {
 		headerSendQueue.PushBack(header)
-	}
-
-	log.Debug("mylog,%t,%t", p.WantsHeaders(), p.RevertToInv())
-	for e := headerSendQueue.Front(); e != nil; e = e.Next() {
-		header := e.Value.(*block.BlockHeader)
-		log.Debug("mylog,%s,%v", p.Addr(), header.GetHash())
 	}
 
 	if p.WantsHeaders() {
@@ -1773,7 +1767,7 @@ func (p *Peer) AddHeadersToSendQ(headers []*block.BlockHeader)  {
 		}
 	}
 	invMsg := wire.NewMsgInvSizeHint(1)
-	// RevertToInv occured, should send only last header via INV
+	// RevertToInv occurred, should send only last header via INV
 	// and just drop other headers, to wait peer request themselves
 	if e := headerSendQueue.Back(); e != nil {
 		header := headerSendQueue.Remove(e).(*block.BlockHeader)
@@ -1793,7 +1787,7 @@ func (p *Peer) CheckRevertToInv(hash *util.Hash) {
 		gChain := chain.GetInstance()
 		tipheight := gChain.TipHeight()
 		locatorheight := gChain.GetSpendHeight(hash)
-		if tipheight < locatorheight + REVERT_TO_INV_DIFF {
+		if tipheight < locatorheight+REVERT_TO_INV_DIFF {
 			p.SetRevertToInv(false)
 		}
 	}
@@ -2189,24 +2183,24 @@ func newPeerBase(origCfg *Config, inbound bool, isWhitelisted bool) *Peer {
 	}
 
 	p := Peer{
-		inbound:         inbound,
-		wireEncoding:    wire.BaseEncoding,
-		knownInventory:  newMruInventoryMap(maxKnownInventory),
-		stallControl:    make(chan stallControlMsg, 1), // nonblocking sync
-		outputQueue:     make(chan outMsg, outputBufferSize),
-		sendQueue:       make(chan outMsg, 1),   // nonblocking sync
-		sendDoneQueue:   make(chan struct{}, 1), // nonblocking sync
-		outputInvChan:   make(chan *wire.InvVect, outputBufferSize),
-		outputHeaderChan:   make(chan *block.BlockHeader, outputBufferSize),
-		outputHeadersChan:   make(chan []*block.BlockHeader, outputBufferSize),
-		inQuit:          make(chan struct{}),
-		queueQuit:       make(chan struct{}),
-		outQuit:         make(chan struct{}),
-		quit:            make(chan struct{}),
-		Cfg:             cfg, // Copy so caller can't mutate.
-		services:        cfg.Services,
-		protocolVersion: cfg.ProtocolVersion,
-		isWhitelisted:   isWhitelisted,
+		inbound:           inbound,
+		wireEncoding:      wire.BaseEncoding,
+		knownInventory:    newMruInventoryMap(maxKnownInventory),
+		stallControl:      make(chan stallControlMsg, 1), // nonblocking sync
+		outputQueue:       make(chan outMsg, outputBufferSize),
+		sendQueue:         make(chan outMsg, 1),   // nonblocking sync
+		sendDoneQueue:     make(chan struct{}, 1), // nonblocking sync
+		outputInvChan:     make(chan *wire.InvVect, outputBufferSize),
+		outputHeaderChan:  make(chan *block.BlockHeader, outputBufferSize),
+		outputHeadersChan: make(chan []*block.BlockHeader, outputBufferSize),
+		inQuit:            make(chan struct{}),
+		queueQuit:         make(chan struct{}),
+		outQuit:           make(chan struct{}),
+		quit:              make(chan struct{}),
+		Cfg:               cfg, // Copy so caller can't mutate.
+		services:          cfg.Services,
+		protocolVersion:   cfg.ProtocolVersion,
+		isWhitelisted:     isWhitelisted,
 	}
 	return &p
 }

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"github.com/copernet/copernicus/errcode"
 	"github.com/copernet/copernicus/net/socks"
+	"github.com/copernet/copernicus/persist"
 	"io"
 	"math/rand"
 	"net"
@@ -74,6 +75,9 @@ const (
 	// max blocks to announce during inventory relay
 	// increase the num in case cut out inv
 	maxBlocksToAnnounce = 8
+
+	// when peer is neer to tip, set its revertToInv to false back
+	REVERT_TO_INV_DIFF = 7
 )
 
 var (
@@ -1765,6 +1769,19 @@ cleanup:
 	}
 	close(p.queueQuit)
 	log.Trace("Peer queue handler done for %s", p)
+}
+
+func (p *Peer) CheckRevertToInv(hash *util.Hash) {
+	if p.RevertToInv() {
+		persist.CsMain.Lock()
+		defer persist.CsMain.Unlock()
+		gChain := chain.GetInstance()
+		tipheight := gChain.TipHeight()
+		locatorheight := gChain.GetSpendHeight(hash)
+		if tipheight < locatorheight + REVERT_TO_INV_DIFF {
+			p.SetRevertToInv(false)
+		}
+	}
 }
 
 // shouldLogWriteError returns whether or not the passed error, which is

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -1412,7 +1412,9 @@ out:
 				case wire.CmdMerkleBlock:
 					fallthrough
 				case wire.CmdTx:
-					p.requestingDataCnt--
+					if p.requestingDataCnt > 0 {
+						p.requestingDataCnt--
+					}
 					if p.requestingDataCnt > 0 {
 						deadline := time.Now().Add(stallResponseTimeout)
 						pendingResponses[wire.CmdBlock] = deadline

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -494,6 +494,7 @@ type Peer struct {
 	sendDoneQueue     chan struct{}
 	outputInvChan     chan *wire.InvVect
 	outputHeaderChan     chan *block.BlockHeader
+	outputHeadersChan     chan []*block.BlockHeader
 	inQuit            chan struct{}
 	queueQuit         chan struct{}
 	outQuit           chan struct{}
@@ -1661,16 +1662,31 @@ out:
 				invSendQueue.PushBack(iv)
 			}
 
-		case iv := <-p.outputHeaderChan:
+		case header := <-p.outputHeaderChan:
 			// No handshake?  They'll find out soon enough.
 			if p.VersionKnown() {
-				headerSendQueue.PushBack(iv)
+				headerSendQueue.PushBack(header)
+			}
+
+
+		case headers := <-p.outputHeadersChan:
+			// No handshake?  They'll find out soon enough.
+			if p.VersionKnown() {
+				for _, header := range headers{
+					headerSendQueue.PushBack(header)
+				}
 			}
 
 		case <-headerTrickleTicker.C:
 			if atomic.LoadInt32(&p.disconnect) != 0 ||
 				headerSendQueue.Len() == 0{
 				continue
+			}
+
+			log.Debug("mylog,%t,%t", p.WantsHeaders(), p.RevertToInv())
+			for e := headerSendQueue.Front(); e != nil; e = e.Next() {
+				header := e.Value.(*block.BlockHeader)
+				log.Debug("mylog,%s,%v",p.Addr(),header.GetHash())
 			}
 
 			if p.WantsHeaders() {
@@ -1784,6 +1800,7 @@ cleanup:
 			// Just drain channel
 			// sendDoneQueue is buffered so doesn't need draining.
 		case <-p.outputHeaderChan:
+		case <-p.outputHeadersChan:
 		default:
 			break cleanup
 		}
@@ -1958,6 +1975,14 @@ func (p *Peer) QueueHeaders(header *block.BlockHeader) {
 	}
 
 	p.outputHeaderChan <- header
+}
+
+func (p *Peer) QueueBatchHeaders(headers []*block.BlockHeader) {
+	if !p.Connected() {
+		return
+	}
+
+	p.outputHeadersChan <- headers
 }
 // QueueInventory adds the passed inventory to the inventory send queue which
 // might not be sent right away, rather it is trickled to the peer in batches.
@@ -2189,6 +2214,7 @@ func newPeerBase(origCfg *Config, inbound bool, isWhitelisted bool) *Peer {
 		sendDoneQueue:   make(chan struct{}, 1), // nonblocking sync
 		outputInvChan:   make(chan *wire.InvVect, outputBufferSize),
 		outputHeaderChan:   make(chan *block.BlockHeader, outputBufferSize),
+		outputHeadersChan:   make(chan []*block.BlockHeader, outputBufferSize),
 		inQuit:          make(chan struct{}),
 		queueQuit:       make(chan struct{}),
 		outQuit:         make(chan struct{}),

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -1199,11 +1199,11 @@ func (p *Peer) HandleVersionMsg(msg *wire.MsgVersion) {
 // recent clients (protocol version > BIP0031Version), it replies with a pong
 // message.  For older clients, it does nothing and anything other than failure
 // is considered a successful ping.
-func (p *Peer) HandlePingMsg(msg *wire.MsgPing) {
+func (p *Peer) HandlePingMsg(nonce uint64, done chan<- struct{}) {
 	// Only reply with pong if the message is from a new enough client.
 	if p.ProtocolVersion() > wire.BIP0031Version {
 		// Include nonce from ping so pong can be identified.
-		p.QueueMessage(wire.NewMsgPong(msg.Nonce), nil)
+		p.QueueMessage(wire.NewMsgPong(nonce), done)
 	}
 }
 
@@ -1609,11 +1609,9 @@ out:
 func (p *Peer) queueHandler() {
 	pendingMsgs := list.New()
 	invSendQueue := list.New()
-	headerSendQueue := list.New()
+
 	trickleTicker := time.NewTicker(trickleTimeout)
 	defer trickleTicker.Stop()
-	headerTrickleTicker := time.NewTicker(headerTrickleTimeout)
-	defer headerTrickleTicker.Stop()
 
 	// We keep the waiting flag so that we know if we have a message queued
 	// to the outHandler or not.  We could use the presence of a head of
@@ -1625,11 +1623,11 @@ func (p *Peer) queueHandler() {
 	waiting := false
 
 	// To avoid duplication below.
-	queuePacket := func(msg outMsg, list *list.List, waiting bool) bool {
+	queuePacket := func(msg outMsg, waiting bool) bool {
 		if !waiting {
 			p.sendQueue <- msg
 		} else {
-			list.PushBack(msg)
+			pendingMsgs.PushBack(msg)
 		}
 		// we are always waiting now.
 		return true
@@ -1638,7 +1636,7 @@ out:
 	for {
 		select {
 		case msg := <-p.outputQueue:
-			waiting = queuePacket(msg, pendingMsgs, waiting)
+			waiting = queuePacket(msg, waiting)
 
 			// This channel is notified when a message has been sent across
 			// the network socket.
@@ -1661,73 +1659,12 @@ out:
 				invSendQueue.PushBack(iv)
 			}
 
-		case header := <-p.outputHeaderChan:
-			if p.VersionKnown() {
-				headerSendQueue.PushBack(header)
-			}
-
-		case headers := <-p.outputHeadersChan:
-			if p.VersionKnown() {
-				for _, header := range headers{
-					headerSendQueue.PushBack(header)
-				}
-			}
-
-		case <-headerTrickleTicker.C:
-			if atomic.LoadInt32(&p.disconnect) != 0 ||
-				headerSendQueue.Len() == 0{
-				continue
-			}
-
-			log.Debug("mylog,%t,%t", p.WantsHeaders(), p.RevertToInv())
-			for e := headerSendQueue.Front(); e != nil; e = e.Next() {
-				header := e.Value.(*block.BlockHeader)
-				log.Debug("mylog,%s,%v",p.Addr(),header.GetHash())
-			}
-
-			if p.WantsHeaders() {
-				if headerSendQueue.Len() <= maxBlocksToAnnounce {
-					if !p.RevertToInv() {
-						msgHeaders := wire.NewMsgHeaders()
-						for e := headerSendQueue.Front(); e != nil; e = headerSendQueue.Front() {
-							header := headerSendQueue.Remove(e).(*block.BlockHeader)
-							if err := msgHeaders.AddBlockHeader(header); err != nil {
-								log.Error("Failed to add block"+
-									" header: %v", err)
-								continue
-							}
-						}
-						if len(msgHeaders.Headers) > 0 {
-							waiting = queuePacket(outMsg{msg: msgHeaders},
-								pendingMsgs, waiting)
-						}
-					}
-				} else {
-					p.SetRevertToInv(true)
-				}
-			}
-
-			invMsg := wire.NewMsgInvSizeHint(1)
-			// RevertToInv occured, should send only last header via INV
-			// and just drop other headers, to wait peer request themselves
-			if e := headerSendQueue.Back(); e != nil {
-				header := headerSendQueue.Remove(e).(*block.BlockHeader)
-				iv := &wire.InvVect{Type: wire.InvTypeBlock, Hash: header.GetHash()}
-
-				invMsg.AddInvVect(iv)
-				waiting = queuePacket(
-					outMsg{msg: invMsg},
-					pendingMsgs, waiting)
-
-				headerSendQueue.Init()
-			}
-
 		case <-trickleTicker.C:
 			// Don't send anything if we're disconnecting or there
 			// is no queued inventory.
 			// version is known if send queue has any entries.
 			if atomic.LoadInt32(&p.disconnect) != 0 ||
-				invSendQueue.Len() == 0{
+				invSendQueue.Len() == 0 {
 				continue
 			}
 
@@ -1753,9 +1690,7 @@ out:
 
 				invMsg.AddInvVect(iv)
 				if len(invMsg.InvList) >= maxInvTrickleSize {
-					waiting = queuePacket(
-						outMsg{msg: invMsg},
-						pendingMsgs, waiting)
+					waiting = queuePacket(outMsg{msg: invMsg}, waiting)
 					invMsg = wire.NewMsgInvSizeHint(uint(invSendQueue.Len()))
 				}
 
@@ -1768,8 +1703,7 @@ out:
 				invMsg.AddInvVect(invlastblock)
 			}
 			if len(invMsg.InvList) != 0 {
-				waiting = queuePacket(outMsg{msg: invMsg},
-					pendingMsgs, waiting)
+				waiting = queuePacket(outMsg{msg: invMsg}, waiting)
 			}
 		case <-p.quit:
 			break out
@@ -1803,6 +1737,53 @@ cleanup:
 	}
 	close(p.queueQuit)
 	log.Trace("Peer queue handler done for %s", p)
+}
+
+func (p *Peer) AddHeadersToSendQ(headers []*block.BlockHeader)  {
+	headerSendQueue := list.New()
+
+	for _, header := range headers{
+		headerSendQueue.PushBack(header)
+	}
+
+	log.Debug("mylog,%t,%t", p.WantsHeaders(), p.RevertToInv())
+	for e := headerSendQueue.Front(); e != nil; e = e.Next() {
+		header := e.Value.(*block.BlockHeader)
+		log.Debug("mylog,%s,%v", p.Addr(), header.GetHash())
+	}
+
+	if p.WantsHeaders() {
+		if headerSendQueue.Len() <= maxBlocksToAnnounce {
+			if !p.RevertToInv() {
+				msgHeaders := wire.NewMsgHeaders()
+				for e := headerSendQueue.Front(); e != nil; e = headerSendQueue.Front() {
+					header := headerSendQueue.Remove(e).(*block.BlockHeader)
+					if err := msgHeaders.AddBlockHeader(header); err != nil {
+						log.Error("Failed to add block"+
+							" header: %v", err)
+						//continue
+					}
+				}
+				if len(msgHeaders.Headers) > 0 {
+					p.outputQueue <- outMsg{msg: msgHeaders}
+				}
+			}
+		} else {
+			p.SetRevertToInv(true)
+		}
+	}
+	invMsg := wire.NewMsgInvSizeHint(1)
+	// RevertToInv occured, should send only last header via INV
+	// and just drop other headers, to wait peer request themselves
+	if e := headerSendQueue.Back(); e != nil {
+		header := headerSendQueue.Remove(e).(*block.BlockHeader)
+		iv := &wire.InvVect{Type: wire.InvTypeBlock, Hash: header.GetHash()}
+
+		invMsg.AddInvVect(iv)
+		p.outputQueue <- outMsg{msg: invMsg}
+
+		headerSendQueue.Init()
+	}
 }
 
 func (p *Peer) CheckRevertToInv(hash *util.Hash) {
@@ -1970,7 +1951,11 @@ func (p *Peer) QueueHeaders(header *block.BlockHeader) {
 		return
 	}
 
-	p.outputHeaderChan <- header
+	headers := make([]*block.BlockHeader, 0, 1)
+	headers = append(headers, header)
+	if p.VersionKnown() {
+		p.AddHeadersToSendQ(headers)
+	}
 }
 
 func (p *Peer) QueueBatchHeaders(headers []*block.BlockHeader) {
@@ -1978,8 +1963,11 @@ func (p *Peer) QueueBatchHeaders(headers []*block.BlockHeader) {
 		return
 	}
 
-	p.outputHeadersChan <- headers
+	if p.VersionKnown() {
+		p.AddHeadersToSendQ(headers)
+	}
 }
+
 // QueueInventory adds the passed inventory to the inventory send queue which
 // might not be sent right away, rather it is trickled to the peer in batches.
 // Inventory that the peer is already known to have is ignored.

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -72,6 +72,9 @@ const (
 	// inventory to a peer.
 	trickleTimeout = 100 * time.Millisecond
 
+	// ticker duration to relay headers to a peer
+	headerTrickleTimeout = time.Second
+
 	// max blocks to announce during inventory relay
 	// increase the num in case cut out inv
 	maxBlocksToAnnounce = 8
@@ -1608,6 +1611,8 @@ func (p *Peer) queueHandler() {
 	headerSendQueue := list.New()
 	trickleTicker := time.NewTicker(trickleTimeout)
 	defer trickleTicker.Stop()
+	headerTrickleTicker := time.NewTicker(headerTrickleTimeout)
+	defer headerTrickleTicker.Stop()
 
 	// We keep the waiting flag so that we know if we have a message queued
 	// to the outHandler or not.  We could use the presence of a head of
@@ -1662,12 +1667,9 @@ out:
 				headerSendQueue.PushBack(iv)
 			}
 
-		case <-trickleTicker.C:
-			// Don't send anything if we're disconnecting or there
-			// is no queued inventory.
-			// version is known if send queue has any entries.
+		case <-headerTrickleTicker.C:
 			if atomic.LoadInt32(&p.disconnect) != 0 ||
-				(invSendQueue.Len() == 0 && headerSendQueue.Len() == 0){
+				headerSendQueue.Len() == 0{
 				continue
 			}
 
@@ -1708,16 +1710,32 @@ out:
 				headerSendQueue.Init()
 			}
 
+		case <-trickleTicker.C:
+			// Don't send anything if we're disconnecting or there
+			// is no queued inventory.
+			// version is known if send queue has any entries.
+			if atomic.LoadInt32(&p.disconnect) != 0 ||
+				invSendQueue.Len() == 0{
+				continue
+			}
+
 			// Create and send as many inv messages as needed to
 			// drain the inventory send queue.
-			invMsg = wire.NewMsgInvSizeHint(uint(invSendQueue.Len()))
+			invMsg := wire.NewMsgInvSizeHint(uint(invSendQueue.Len()))
 
+			var invlastblock *wire.InvVect
 			for e := invSendQueue.Front(); e != nil; e = invSendQueue.Front() {
 				iv := invSendQueue.Remove(e).(*wire.InvVect)
 
 				// Don't send inventory that became known after
 				// the initial check.
 				if p.knownInventory.Exists(iv) {
+					continue
+				}
+
+				if iv.Type == wire.InvTypeBlock {
+					invlastblock = iv
+					p.AddKnownInventory(iv)
 					continue
 				}
 
@@ -1734,7 +1752,10 @@ out:
 				p.AddKnownInventory(iv)
 			}
 
-			if len(invMsg.InvList) > 0 {
+			if invlastblock != nil {
+				invMsg.AddInvVect(invlastblock)
+			}
+			if len(invMsg.InvList) != 0 {
 				waiting = queuePacket(outMsg{msg: invMsg},
 					pendingMsgs, waiting)
 			}

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -1657,20 +1657,16 @@ out:
 			p.sendQueue <- val.(outMsg)
 
 		case iv := <-p.outputInvChan:
-			// No handshake?  They'll find out soon enough.
 			if p.VersionKnown() {
 				invSendQueue.PushBack(iv)
 			}
 
 		case header := <-p.outputHeaderChan:
-			// No handshake?  They'll find out soon enough.
 			if p.VersionKnown() {
 				headerSendQueue.PushBack(header)
 			}
 
-
 		case headers := <-p.outputHeadersChan:
-			// No handshake?  They'll find out soon enough.
 			if p.VersionKnown() {
 				for _, header := range headers{
 					headerSendQueue.PushBack(header)

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -502,21 +502,15 @@ type Peer struct {
 	newPeerCallback func(*Peer)
 
 	// since when we're stalling block download progress (in microseconds), or 0
-	stallingSinceLock sync.RWMutex
-	stallingSince     int64
+	stallingSince int64
 }
 
 func (p *Peer) GetStallingSince() int64 {
-	p.stallingSinceLock.RLock()
-	since := p.stallingSince
-	p.stallingSinceLock.RUnlock()
-	return since
+	return p.stallingSince
 }
 
 func (p *Peer) SetStallingSince(since int64) {
-	p.stallingSinceLock.Lock()
 	p.stallingSince = since
-	p.stallingSinceLock.Unlock()
 }
 
 func (p *Peer) RequestMemPool() {
@@ -1358,10 +1352,8 @@ out:
 		case msg := <-p.stallControl:
 			switch msg.command {
 			case sccSendMessage:
-				// Add a deadline for the expected response
-				// message if needed.
-				p.maybeAddDeadline(pendingResponses,
-					msg.message)
+				// Add a deadline for the expected response message if needed.
+				p.maybeAddDeadline(pendingResponses, msg.message)
 
 			case sccReceiveMessage:
 				// Remove received messages from the expected
@@ -1388,9 +1380,7 @@ out:
 			case sccHandlerStart:
 				// Warn on unbalanced callback signalling.
 				if handlerActive {
-					log.Warn("Received handler start " +
-						"control command while a " +
-						"handler is already active")
+					log.Warn("Received handler start control command while a handler is already active")
 					continue
 				}
 
@@ -1400,9 +1390,7 @@ out:
 			case sccHandlerDone:
 				// Warn on unbalanced callback signalling.
 				if !handlerActive {
-					log.Warn("Received handler done " +
-						"control command when a " +
-						"handler is not already active")
+					log.Warn("Received handler done control command when a handler is not already active")
 					continue
 				}
 

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -140,9 +140,6 @@ type MessageListeners struct {
 	// OnAddr is invoked when a peer receives an addr bitcoin message.
 	OnAddr func(p *Peer, msg *wire.MsgAddr)
 
-	// OnPing is invoked when a peer receives a ping bitcoin message.
-	OnPing func(p *Peer, msg *wire.MsgPing)
-
 	// OnPong is invoked when a peer receives a pong bitcoin message.
 	OnPong func(p *Peer, msg *wire.MsgPong)
 

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -70,7 +70,7 @@ const (
 
 	// trickleTimeout is the duration of the ticker which trickles down the
 	// inventory to a peer.
-	trickleTimeout = time.Second
+	trickleTimeout = 100 * time.Millisecond
 
 	// max blocks to announce during inventory relay
 	// increase the num in case cut out inv

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -1780,10 +1780,12 @@ func (p *Peer) AddHeadersToSendQ(headers []*block.BlockHeader) {
 	}
 }
 
-func (p *Peer) CheckRevertToInv(hash *util.Hash) {
+func (p *Peer) CheckRevertToInv(hash *util.Hash, needLock bool) {
 	if p.RevertToInv() {
-		persist.CsMain.Lock()
-		defer persist.CsMain.Unlock()
+		if needLock {
+			persist.CsMain.Lock()
+			defer persist.CsMain.Unlock()
+		}
 		gChain := chain.GetInstance()
 		tipheight := gChain.TipHeight()
 		locatorheight := gChain.GetSpendHeight(hash)

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -500,6 +500,23 @@ type Peer struct {
 	reqMempoolOnce sync.Once
 
 	newPeerCallback func(*Peer)
+
+	// since when we're stalling block download progress (in microseconds), or 0
+	stallingSinceLock sync.RWMutex
+	stallingSince     int64
+}
+
+func (p *Peer) GetStallingSince() int64 {
+	p.stallingSinceLock.RLock()
+	since := p.stallingSince
+	p.stallingSinceLock.RUnlock()
+	return since
+}
+
+func (p *Peer) SetStallingSince(since int64) {
+	p.stallingSinceLock.Lock()
+	p.stallingSince = since
+	p.stallingSinceLock.Unlock()
 }
 
 func (p *Peer) RequestMemPool() {

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -8,8 +8,11 @@ import (
 	"context"
 	"errors"
 	"github.com/copernet/copernicus/conf"
+	"github.com/copernet/copernicus/model/bitcointime"
 	"github.com/copernet/copernicus/model/block"
+	"github.com/copernet/copernicus/model/blockindex"
 	"github.com/copernet/copernicus/model/tx"
+	"github.com/copernet/copernicus/persist"
 	"io"
 	"net"
 	"os"
@@ -228,8 +231,61 @@ func testPeer(t *testing.T, p *peer.Peer, s peerStats) {
 	}
 }
 
+func initEnv() {
+	chain.InitGlobalChain()
+	gChain := chain.GetInstance()
+	gChain.SetTip(nil)
+
+	GlobalBlockIndexMap := make(map[util.Hash]*blockindex.BlockIndex)
+	branch := make([]*blockindex.BlockIndex, 0, 20)
+	gChain.InitLoad(GlobalBlockIndexMap, branch)
+
+	persist.InitPersistGlobal()
+
+	bl := gChain.GetParams().GenesisBlock
+	bIndex := blockindex.NewBlockIndex(&bl.Header)
+	bIndex.Height = 0
+	bIndex.TxCount = 1
+	bIndex.ChainTxCount = 1
+	bIndex.AddStatus(blockindex.BlockHaveData)
+	bIndex.RaiseValidity(blockindex.BlockValidTransactions)
+	err := gChain.AddToIndexMap(bIndex)
+	if err != nil {
+		panic("AddToIndexMap fail")
+	}
+
+	genesisIndex := gChain.FindBlockIndex(*gChain.GetParams().GenesisHash)
+	if genesisIndex == nil {
+		panic("genesis index find fail")
+	}
+	gChain.SetTip(genesisIndex)
+	if myserver == nil {
+		s, err := initServer()
+		if err != nil {
+			panic("server init fail")
+		}
+		if s == nil {
+			panic("server nil")
+		}
+		myserver = s
+		s.Start()
+	}
+}
+
+var myserver *server.Server
+
+func initServer() (*server.Server, error) {
+	timeSource := bitcointime.NewMedianTime()
+	s, err := server.NewServer(model.ActiveNetParams, timeSource, nil)
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
 // TestPeerConnection tests connection between inbound and outbound peers.
 func TestPeerConnection(t *testing.T) {
+	initEnv()
 	verack := make(chan struct{})
 	peer1Cfg := &peer.Config{
 		Listeners: peer.MessageListeners{
@@ -247,7 +303,7 @@ func TestPeerConnection(t *testing.T) {
 		UserAgentVersion:  "1.0",
 		UserAgentComments: []string{"comment"},
 		ChainParams:       &model.MainNetParams,
-		ProtocolVersion:   wire.RejectVersion, // Configure with older version
+		ProtocolVersion:   wire.SendHeadersVersion, // Configure with new version
 		Services:          0,
 	}
 	peer2Cfg := &peer.Config{
@@ -256,38 +312,39 @@ func TestPeerConnection(t *testing.T) {
 		UserAgentVersion:  "1.0",
 		UserAgentComments: []string{"comment"},
 		ChainParams:       &model.MainNetParams,
+		ProtocolVersion:   wire.SendHeadersVersion, // Configure with new version
 		Services:          wire.SFNodeNetwork,
 	}
 
 	wantStats1 := peerStats{
 		wantUserAgent:       "/peer:1.0(EB32.0; comment)/",
 		wantServices:        0,
-		wantProtocolVersion: wire.RejectVersion,
+		wantProtocolVersion: wire.SendHeadersVersion,
 		wantConnected:       true,
 		wantVersionKnown:    true,
 		wantVerAckReceived:  true,
-		wantHeaders:         false,
+		wantHeaders:         true,
 		wantLastPingTime:    time.Time{},
 		wantLastPingNonce:   uint64(0),
 		wantLastPingMicros:  int64(0),
 		wantTimeOffset:      int64(0),
-		wantBytesSent:       161, // 137 version + 24 verack
-		wantBytesReceived:   161,
+		wantBytesSent:       188, // 140 version + 24 verack + 24 sendheadersmsg
+		wantBytesReceived:   188,
 	}
 	wantStats2 := peerStats{
 		wantUserAgent:       "/peer:1.0(EB32.0; comment)/",
 		wantServices:        wire.SFNodeNetwork,
-		wantProtocolVersion: wire.RejectVersion,
+		wantProtocolVersion: wire.SendHeadersVersion,
 		wantConnected:       true,
 		wantVersionKnown:    true,
 		wantVerAckReceived:  true,
-		wantHeaders:         false,
+		wantHeaders:         true,
 		wantLastPingTime:    time.Time{},
 		wantLastPingNonce:   uint64(0),
 		wantLastPingMicros:  int64(0),
 		wantTimeOffset:      int64(0),
-		wantBytesSent:       161, // 137 version + 24 verack
-		wantBytesReceived:   161,
+		wantBytesSent:       188, // 140 version + 24 verack + 24 sendheadersmsg
+		wantBytesReceived:   188,
 	}
 
 	tests := []struct {
@@ -302,7 +359,7 @@ func TestPeerConnection(t *testing.T) {
 					&conn{raddr: "10.0.0.2:8333", laddr: "10.0.0.2:18333"},
 				)
 				inMsgChan := make(chan *peer.PeerMessage)
-				server.SetMsgHandle(context.TODO(), inMsgChan, nil)
+				server.SetMsgHandle(context.TODO(), inMsgChan, myserver)
 				inPeer := peer.NewInboundPeer(peer1Cfg, false)
 				inPeer.AssociateConnection(inConn, inMsgChan, func(*peer.Peer) {})
 				inNA := inPeer.NA()
@@ -318,7 +375,7 @@ func TestPeerConnection(t *testing.T) {
 					return nil, nil, err
 				}
 				outMsgChan := make(chan *peer.PeerMessage)
-				server.SetMsgHandle(context.TODO(), outMsgChan, nil)
+				server.SetMsgHandle(context.TODO(), outMsgChan, myserver)
 				outPeer.AssociateConnection(outConn, outMsgChan, func(*peer.Peer) {})
 
 				outNA := outPeer.NA()
@@ -348,7 +405,7 @@ func TestPeerConnection(t *testing.T) {
 					&conn{raddr: "10.0.0.2:8333"},
 				)
 				inMsgChan := make(chan *peer.PeerMessage)
-				server.SetMsgHandle(context.TODO(), inMsgChan, nil)
+				server.SetMsgHandle(context.TODO(), inMsgChan, myserver)
 				inPeer := peer.NewInboundPeer(peer1Cfg, false)
 				inPeer.AssociateConnection(inConn, inMsgChan, func(*peer.Peer) {})
 
@@ -357,7 +414,7 @@ func TestPeerConnection(t *testing.T) {
 					return nil, nil, err
 				}
 				outMsgChan := make(chan *peer.PeerMessage)
-				server.SetMsgHandle(context.TODO(), outMsgChan, nil)
+				server.SetMsgHandle(context.TODO(), outMsgChan, myserver)
 				outPeer.AssociateConnection(outConn, outMsgChan, func(*peer.Peer) {})
 
 				for i := 0; i < 4; i++ {
@@ -378,6 +435,10 @@ func TestPeerConnection(t *testing.T) {
 			t.Errorf("TestPeerConnection setup #%d: unexpected err %v", i, err)
 			return
 		}
+		// Because SendHeadersMsg is sent via channel, here we should sleep to wait
+		// that msg handled and sent.
+		// Otherwise, the test of bytessent & bytesrecv may pass or fail not definitely
+		time.Sleep(time.Second)
 		testPeer(t, inPeer, wantStats2)
 		testPeer(t, outPeer, wantStats1)
 
@@ -390,6 +451,7 @@ func TestPeerConnection(t *testing.T) {
 
 // TestPeerListeners tests that the peer listeners are called as expected.
 func TestPeerListeners(t *testing.T) {
+	initEnv()
 	verack := make(chan struct{}, 1)
 	ok := make(chan wire.Message, 20)
 	peerCfg := &peer.Config{
@@ -483,7 +545,7 @@ func TestPeerListeners(t *testing.T) {
 		&conn{raddr: "10.0.0.2:8333"},
 	)
 	inMsgChan := make(chan *peer.PeerMessage)
-	server.SetMsgHandle(context.TODO(), inMsgChan, nil)
+	server.SetMsgHandle(context.TODO(), inMsgChan, myserver)
 	inPeer := peer.NewInboundPeer(peerCfg, false)
 	inPeer.AssociateConnection(inConn, inMsgChan, func(*peer.Peer) {})
 
@@ -500,7 +562,7 @@ func TestPeerListeners(t *testing.T) {
 		return
 	}
 	outMsgChan := make(chan *peer.PeerMessage)
-	server.SetMsgHandle(context.TODO(), outMsgChan, nil)
+	server.SetMsgHandle(context.TODO(), outMsgChan, myserver)
 	outPeer.AssociateConnection(outConn, outMsgChan, func(*peer.Peer) {})
 
 	for i := 0; i < 2; i++ {
@@ -632,8 +694,9 @@ func TestPeerListeners(t *testing.T) {
 
 // TestOutboundPeer tests that the outbound peer works as expected.
 func TestOutboundPeer(t *testing.T) {
+	initEnv()
 	msgChan := make(chan *peer.PeerMessage)
-	server.SetMsgHandle(context.TODO(), msgChan, nil)
+	server.SetMsgHandle(context.TODO(), msgChan, myserver)
 
 	peerCfg := &peer.Config{
 		NewestBlock: func() (*util.Hash, int32, error) {
@@ -703,7 +766,7 @@ func TestOutboundPeer(t *testing.T) {
 	}
 
 	msgChan1 := make(chan *peer.PeerMessage)
-	server.SetMsgHandle(context.TODO(), msgChan1, nil)
+	server.SetMsgHandle(context.TODO(), msgChan1, myserver)
 
 	peerCfg.NewestBlock = newestBlock
 	r1, w1 := io.Pipe()
@@ -736,7 +799,7 @@ func TestOutboundPeer(t *testing.T) {
 	p1.Disconnect()
 
 	msgChan2 := make(chan *peer.PeerMessage)
-	server.SetMsgHandle(context.TODO(), msgChan2, nil)
+	server.SetMsgHandle(context.TODO(), msgChan2, myserver)
 	// Test regression
 	peerCfg.ChainParams = &model.RegressionNetParams
 	peerCfg.Services = wire.SFNodeBloom
@@ -787,8 +850,9 @@ func TestOutboundPeer(t *testing.T) {
 // Tests that the node disconnects from peers with an unsupported protocol
 // version.
 func TestUnsupportedVersionPeer(t *testing.T) {
+	initEnv()
 	msgChan := make(chan *peer.PeerMessage)
-	server.SetMsgHandle(context.TODO(), msgChan, nil)
+	server.SetMsgHandle(context.TODO(), msgChan, myserver)
 	peerCfg := &peer.Config{
 		UserAgentName:     "peer",
 		UserAgentVersion:  "1.0",

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -50,6 +50,7 @@ type conn struct {
 
 func TestMain(m *testing.M) {
 	conf.Cfg = conf.InitConfig([]string{})
+	initEnv()
 	os.Exit(m.Run())
 }
 
@@ -285,7 +286,6 @@ func initServer() (*server.Server, error) {
 
 // TestPeerConnection tests connection between inbound and outbound peers.
 func TestPeerConnection(t *testing.T) {
-	initEnv()
 	verack := make(chan struct{})
 	peer1Cfg := &peer.Config{
 		Listeners: peer.MessageListeners{
@@ -451,7 +451,6 @@ func TestPeerConnection(t *testing.T) {
 
 // TestPeerListeners tests that the peer listeners are called as expected.
 func TestPeerListeners(t *testing.T) {
-	initEnv()
 	verack := make(chan struct{}, 1)
 	ok := make(chan wire.Message, 20)
 	peerCfg := &peer.Config{
@@ -691,7 +690,6 @@ func TestPeerListeners(t *testing.T) {
 
 // TestOutboundPeer tests that the outbound peer works as expected.
 func TestOutboundPeer(t *testing.T) {
-	initEnv()
 	msgChan := make(chan *peer.PeerMessage)
 	server.SetMsgHandle(context.TODO(), msgChan, myserver)
 
@@ -847,7 +845,6 @@ func TestOutboundPeer(t *testing.T) {
 // Tests that the node disconnects from peers with an unsupported protocol
 // version.
 func TestUnsupportedVersionPeer(t *testing.T) {
-	initEnv()
 	msgChan := make(chan *peer.PeerMessage)
 	server.SetMsgHandle(context.TODO(), msgChan, myserver)
 	peerCfg := &peer.Config{

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"github.com/copernet/copernicus/conf"
-	"github.com/copernet/copernicus/model/bitcointime"
 	"github.com/copernet/copernicus/model/block"
 	"github.com/copernet/copernicus/model/blockindex"
 	"github.com/copernet/copernicus/model/tx"
@@ -276,7 +275,7 @@ func initEnv() {
 var myserver *server.Server
 
 func initServer() (*server.Server, error) {
-	timeSource := bitcointime.NewMedianTime()
+	timeSource := util.GetTimeSource()
 	s, err := server.NewServer(model.ActiveNetParams, timeSource, nil)
 	if err != nil {
 		return nil, err

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -275,7 +275,7 @@ func initEnv() {
 var myserver *server.Server
 
 func initServer() (*server.Server, error) {
-	timeSource := util.GetTimeSource()
+	timeSource := util.GetGlobalMedianTime()
 	s, err := server.NewServer(model.ActiveNetParams, timeSource, nil)
 	if err != nil {
 		return nil, err

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -275,7 +275,7 @@ func initEnv() {
 var myserver *server.Server
 
 func initServer() (*server.Server, error) {
-	timeSource := util.GetGlobalMedianTime()
+	timeSource := util.GetMedianTimeSource()
 	s, err := server.NewServer(model.ActiveNetParams, timeSource, nil)
 	if err != nil {
 		return nil, err
@@ -327,8 +327,8 @@ func TestPeerConnection(t *testing.T) {
 		wantLastPingNonce:   uint64(0),
 		wantLastPingMicros:  int64(0),
 		wantTimeOffset:      int64(0),
-		wantBytesSent:       188, // 140 version + 24 verack + 24 sendheadersmsg
-		wantBytesReceived:   188,
+		wantBytesSent:       185, // 137 version + 24 verack + 24 sendheadersmsg
+		wantBytesReceived:   185,
 	}
 	wantStats2 := peerStats{
 		wantUserAgent:       "/peer:1.0(EB32.0; comment)/",
@@ -342,8 +342,8 @@ func TestPeerConnection(t *testing.T) {
 		wantLastPingNonce:   uint64(0),
 		wantLastPingMicros:  int64(0),
 		wantTimeOffset:      int64(0),
-		wantBytesSent:       188, // 140 version + 24 verack + 24 sendheadersmsg
-		wantBytesReceived:   188,
+		wantBytesSent:       185, // 137 version + 24 verack + 24 sendheadersmsg
+		wantBytesReceived:   185,
 	}
 
 	tests := []struct {

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -468,9 +468,6 @@ func TestPeerListeners(t *testing.T) {
 			OnAddr: func(p *peer.Peer, msg *wire.MsgAddr) {
 				ok <- msg
 			},
-			OnPing: func(p *peer.Peer, msg *wire.MsgPing) {
-				ok <- msg
-			},
 			OnPong: func(p *peer.Peer, msg *wire.MsgPong) {
 				ok <- msg
 			},

--- a/persist/blkdb/blkdb.go
+++ b/persist/blkdb/blkdb.go
@@ -257,15 +257,6 @@ func (blockTreeDB *BlockTreeDB) LoadBlockIndexGuts(blkIdxMap map[util.Hash]*bloc
 			return false
 		}
 
-		if bi.TxCount == 0 {
-			err := blockTreeDB.dbw.Erase(k, true)
-			if err != nil {
-				log.Error("LoadBlockIndexGuts: BlockIndex erase err:%v", err)
-				return false
-			}
-			cursor.Next()
-			continue
-		}
 		newIndex := insertBlockIndex(*bi.GetBlockHash(), blkIdxMap)
 		if newIndex == nil {
 			cursor.Next()

--- a/rpc/rpcblockchain.go
+++ b/rpc/rpcblockchain.go
@@ -68,7 +68,7 @@ func handleGetBlockChainInfo(s *Server, cmd interface{}, closeChan <-chan struct
 	chainInfo := &btcjson.GetBlockChainInfoResult{
 		Chain:                params.Name,
 		Blocks:               gChain.Height(),
-		Headers:              gChain.Height(), // TODO: NOT support header-first yet
+		Headers:              gChain.GetIndexBestHeader().Height,
 		BestBlockHash:        tip.GetBlockHash().String(),
 		Difficulty:           getDifficulty(tip),
 		MedianTime:           tip.GetMedianTimePast(),

--- a/rpc/rpcblockchain.go
+++ b/rpc/rpcblockchain.go
@@ -369,6 +369,9 @@ func handleGetChainTips(s *Server, cmd interface{}, closeChan <-chan struct{}) (
 	setTips := set.New() // element type:
 	gchain := chain.GetInstance()
 
+	persist.CsMain.Lock() //to protect chain.indexMap
+	defer persist.CsMain.Unlock()
+
 	setTips = gchain.GetChainTips()
 
 	tips := make([]btcjson.ChainTipsInfo, 0, setTips.Size())

--- a/rpc/rpcserver.go
+++ b/rpc/rpcserver.go
@@ -374,9 +374,9 @@ func (s *Server) jsonRPCRead(w http.ResponseWriter, r *http.Request, isAdmin boo
 			if parsedCmd.err != nil {
 				jsonErr = parsedCmd.err
 			} else {
-				//log.Trace(">rpc:: %s, %+v", parsedCmd.method, parsedCmd.cmd)
 				log.Trace(">rpc:: %s", parsedCmd.method)
 				result, jsonErr = s.standardCmdResult(parsedCmd, closeChan)
+				log.Trace("<rpc:: %s", parsedCmd.method)
 			}
 		}
 	}

--- a/service/blockservice.go
+++ b/service/blockservice.go
@@ -19,7 +19,7 @@ func ProcessBlockHeader(headerList []*block.BlockHeader, lastIndex *blockindex.B
 		if err != nil {
 			return err
 		}
-		lastIndex = index
+		*lastIndex = *index
 	}
 	beginHash := headerList[0].GetHash()
 	endHash := headerList[len(headerList)-1].GetHash()

--- a/service/blockservice.go
+++ b/service/blockservice.go
@@ -80,7 +80,7 @@ func ProcessNewBlock(pblock *block.Block, forceProcessing bool, fNewBlock *bool)
 		return err
 	}
 
-	chain.GetInstance().SendNotification(chain.NTBlockAccepted, pblock)
+	//chain.GetInstance().SendNotification(chain.NTBlockAccepted, pblock)
 
 	if err := lchain.CheckBlockIndex(); err != nil {
 		log.Error("check block index failed, please check: %v", err)

--- a/service/blockservice.go
+++ b/service/blockservice.go
@@ -14,17 +14,21 @@ import (
 
 func ProcessBlockHeader(headerList []*block.BlockHeader, lastIndex *blockindex.BlockIndex) error {
 	log.Debug("ProcessBlockHeader begin, header number : %d", len(headerList))
+	lastheight := int32(-1)
 	for _, header := range headerList {
 		index, err := lblock.AcceptBlockHeader(header)
 		if err != nil {
 			return err
 		}
-		*lastIndex = *index
+		if lastIndex != nil {
+			*lastIndex = *index
+		}
+		lastheight = index.Height
 	}
 	beginHash := headerList[0].GetHash()
 	endHash := headerList[len(headerList)-1].GetHash()
 	log.Trace("processBlockHeader success, blockNumber : %d, lastBlockHeight : %d, beginBlockHash : %s, "+
-		"endBlockHash : %s. ", len(headerList), lastIndex.Height, beginHash, endHash)
+		"endBlockHash : %s. ", len(headerList), lastheight, beginHash, endHash)
 	return nil
 }
 


### PR DESCRIPTION
1, fully support headers-first function in p2p msg, include BIP130 sendheaders message
2, keep same with abc, use headers-first mode by default
3, fix several bugs about net & server during the developing
4, run pass the function test of sendheaders.py, which have 5 kinds of test cases about headers-first and re-org chain
5, upgrade the corresponding unit test of syncmanager, and the coverage is upon 80%

@qiwei9743 @whunmr please help review the related code