### PR TITLE
Fix a data race of unit test of server

### DIFF
--- a/net/server/server.go
+++ b/net/server/server.go
@@ -661,7 +661,9 @@ func (sp *serverPeer) doGetData(msg *wire.MsgGetData, done chan<- struct{}) {
 	// bursts of small requests are not penalized as that would potentially ban
 	// peers performing IBD.
 	// This incremental score decays each minute to half of its value.
-	sp.addBanScore(0, uint32(length)*99/wire.MaxInvPerMsg, "getdata")
+	if score := uint32(length) * 99 / wire.MaxInvPerMsg; score != 0 {
+		sp.addBanScore(0, score, "getdata")
+	}
 
 	// We wait on this wait channel periodically to prevent queuing
 	// far more data than we can send in a reasonable time, wasting memory.

--- a/net/server/server_test.go
+++ b/net/server/server_test.go
@@ -876,9 +876,16 @@ func TestOnGetBlocks(t *testing.T) {
 }
 
 func TestOnFilterAdd(t *testing.T) {
+	chn := make(chan struct{})
+	svr, err := NewServer(model.ActiveNetParams, nil, chn)
+	assert.Nil(t, err)
+
+	svr.Start()
+	defer svr.Stop()
+
 	config := peer.Config{}
 	in := peer.NewInboundPeer(&config, false)
-	sp := newServerPeer(s, false)
+	sp := newServerPeer(svr, false)
 	sp.Peer = in
 	data := []byte{0x01, 0x02}
 	msg := wire.NewMsgFilterAdd(data)
@@ -904,9 +911,16 @@ func TestOnFeeFilter(t *testing.T) {
 }
 
 func TestOnFilterClear(t *testing.T) {
+	chn := make(chan struct{})
+	svr, err := NewServer(model.ActiveNetParams, nil, chn)
+	assert.Nil(t, err)
+
+	svr.Start()
+	defer svr.Stop()
+
 	config := peer.Config{}
 	in := peer.NewInboundPeer(&config, false)
-	sp := newServerPeer(s, false)
+	sp := newServerPeer(svr, false)
 	sp.Peer = in
 	msg := wire.NewMsgFilterClear()
 	sp.server.services |= wire.SFNodeBloom
@@ -914,9 +928,16 @@ func TestOnFilterClear(t *testing.T) {
 }
 
 func TestOnFilterLoad(t *testing.T) {
+	chn := make(chan struct{})
+	svr, err := NewServer(model.ActiveNetParams, nil, chn)
+	assert.Nil(t, err)
+
+	svr.Start()
+	defer svr.Stop()
+
 	config := peer.Config{}
 	in := peer.NewInboundPeer(&config, false)
-	sp := newServerPeer(s, false)
+	sp := newServerPeer(svr, false)
 	sp.Peer = in
 	data := []byte{0x01, 0x02}
 	msg := wire.NewMsgFilterLoad(data, 10, 0, 0)
@@ -1604,7 +1625,14 @@ func TestServer_transferPing(t *testing.T) {
 }
 
 func TestServer_enforceNodeBloomFlag(t *testing.T) {
-	sp := newServerPeer(s, false)
+	chn := make(chan struct{})
+	svr, err := NewServer(model.ActiveNetParams, nil, chn)
+	assert.Nil(t, err)
+
+	svr.Start()
+	defer svr.Stop()
+
+	sp := newServerPeer(svr, false)
 	sp.Peer = peer.NewInboundPeer(newPeerConfig(sp), false)
 	conf.Cfg.P2PNet.DisableBanning = true
 	sp.server.services = 0

--- a/net/server/server_test.go
+++ b/net/server/server_test.go
@@ -1586,32 +1586,25 @@ func TestServer_OnGetHeaders_hasheader(t *testing.T) {
 	sp.OnGetHeaders(nil, msg)
 }
 
-func TestServer_addBanScore_ignore_whitelist(t *testing.T) {
+func TestServer_addBanScore(t *testing.T) {
+	//test whitelist
 	sp := newServerPeer(s, false)
 	sp.Peer = peer.NewInboundPeer(newPeerConfig(sp), true)
 	sp.addBanScore(88, 88, "testban")
-
 	assert.Equal(t, uint32(0), sp.banScore.Int())
-}
 
-func TestServer_addBanScore_ignore_disable(t *testing.T) {
+	//test zero
 	p := &peer.Peer{}
-	sp := newServerPeer(s, false)
+	sp = newServerPeer(s, false)
 	sp.Peer = p
-	conf.Cfg.P2PNet.DisableBanning = true
-	sp.addBanScore(88, 88, "testban")
-
-	assert.Equal(t, uint32(0), sp.banScore.Int())
-}
-
-func TestServer_addBanScore_zero(t *testing.T) {
-	p := &peer.Peer{}
-	sp := newServerPeer(s, false)
-	sp.Peer = p
-	conf.Cfg.P2PNet.DisableBanning = false
 	sp.addBanScore(111, 111, "testban")
 	assert.Equal(t, uint32(222), sp.banScore.Int())
 	sp.addBanScore(0, 0, "testban")
+	assert.Equal(t, uint32(222), sp.banScore.Int())
+
+	//test ignore disable
+	conf.Cfg.P2PNet.DisableBanning = true
+	sp.addBanScore(88, 88, "testban")
 	assert.Equal(t, uint32(222), sp.banScore.Int())
 }
 


### PR DESCRIPTION
And lower the possibility of data race of Cfg.DisableBanning:
because the Cfg global var is without any lock, but I need to modify it to test a unit case,
so until now we can lower the data race occurring possibility , but we can't absolutely avoid that.