### PR TITLE
Add initial-headers-sync timeout handling to fix issue #217

### DIFF
--- a/net/syncmanager/syncmanager.go
+++ b/net/syncmanager/syncmanager.go
@@ -213,8 +213,8 @@ func (pss *peerSyncState) onStartSync(syncPeer *peer.Peer) {
 
 	pss.headersSyncTimeout =
 		util.GetTimeMicroSec() +
-		timeoutBase +
-		timeoutPerHeader * headersToSync
+			timeoutBase +
+			timeoutPerHeader*headersToSync
 
 	log.Info("start to sync %d headers from peer(%s),", headersToSync, syncPeer.Addr())
 }
@@ -228,7 +228,7 @@ func (sm *SyncManager) checkIBDHeadersSync() {
 
 	bestHeader := chain.GetInstance().GetIndexBestHeader()
 
-	if int64(bestHeader.GetBlockTime()) > (util.GetAdjustedTimeSec() - 24 * 60 * 60) {
+	if int64(bestHeader.GetBlockTime()) > (util.GetAdjustedTimeSec() - 24*60*60) {
 		log.Info("headers synced from peer:%s", sm.syncPeer.Addr())
 		//reset the timeout so we can't trigger disconnect later.
 		state.headersSyncTimeout = 0
@@ -589,7 +589,7 @@ func (sm *SyncManager) fetchMissingTx(missTxs []util.Hash, peer peer.MsgSender) 
 // current returns true if we believe we are synced with our peers, false if we
 // still have blocks to check
 func (sm *SyncManager) current() bool {
-	if !chain.GetInstance().IsCurrent() {
+	if lblock.IsInitialBlockDownload() {
 		return false
 	}
 

--- a/net/syncmanager/syncmanager.go
+++ b/net/syncmanager/syncmanager.go
@@ -202,9 +202,6 @@ type peerSyncState struct {
 
 func (pss *peerSyncState) onStartSync(syncPeer *peer.Peer) {
 	bestHeader := chain.GetInstance().GetIndexBestHeader()
-	if bestHeader == nil {
-		bestHeader = chain.GetInstance().Tip()
-	}
 
 	timeToCatchUp := util.GetAdjustedTimeSec() - int64(bestHeader.GetBlockTime())
 	headersToSync := timeToCatchUp / int64(model.ActiveNetParams.TargetTimePerBlock)
@@ -230,9 +227,6 @@ func (sm *SyncManager) checkIBDHeadersSync() {
 	state := sm.peerStates[sm.syncPeer]
 
 	bestHeader := chain.GetInstance().GetIndexBestHeader()
-	if bestHeader == nil {
-		bestHeader = chain.GetInstance().Tip()
-	}
 
 	if int64(bestHeader.GetBlockTime()) > (util.GetAdjustedTimeSec() - 24 * 60 * 60) {
 		log.Info("headers synced from peer:%s", sm.syncPeer.Addr())
@@ -356,12 +350,7 @@ func (sm *SyncManager) startSync() {
 	// Start syncing from the best peer if one was selected.
 	if bestPeer != nil {
 		activeChain := chain.GetInstance()
-		pindexBestHeader := activeChain.GetIndexBestHeader()
-		if pindexBestHeader == nil {
-			pindexBestHeader = activeChain.Tip()
-			activeChain.SetIndexBestHeader(pindexBestHeader)
-		}
-		pindexStart := pindexBestHeader
+		pindexStart := activeChain.GetIndexBestHeader()
 		/**
 		 * If possible, start at the block preceding the currently best
 		 * known header. This ensures that we always get a non-empty list of
@@ -444,12 +433,7 @@ func (sm *SyncManager) handleNewPeerMsg(peer *peer.Peer) {
 
 	if !lblock.IsInitialBlockDownload() && peer.VerAckReceived() {
 		gChain := chain.GetInstance()
-		pindexBestHeader := gChain.GetIndexBestHeader()
-		if pindexBestHeader == nil {
-			pindexBestHeader = gChain.Tip()
-			gChain.SetIndexBestHeader(pindexBestHeader)
-		}
-		pindexStart := pindexBestHeader
+		pindexStart := gChain.GetIndexBestHeader()
 		if pindexStart.Prev != nil {
 			pindexStart = pindexStart.Prev
 		}

--- a/net/syncmanager/syncmanager_test.go
+++ b/net/syncmanager/syncmanager_test.go
@@ -1209,11 +1209,7 @@ func TestSyncManager_startsync_alreadysync(t *testing.T) {
 	sm.peerStates[inpeer] = syncState
 	inpeer.UpdateLastBlockHeight(1024)
 	inpeer.SetAckReceived(true)
-	gChain := chain.GetInstance()
-	bak := gChain.GetIndexBestHeader()
-	gChain.SetIndexBestHeader(nil)
 	sm.startSync()
-	gChain.SetIndexBestHeader(bak)
 	sm.Stop()
 }
 


### PR DESCRIPTION
- Add initial-headers-sync timeout handling to fix issue #217
    - initial-headers-sync Timeout = base + per_header * (expected number of headers)
    - testing log:

```
2018/12/14 09:46:23.789 [E] [syncmanager.go:237]  disconnect timeout sync peer:213.227.140.194:8333
2018/12/14 09:46:23.789 [E] [syncmanager.go:243]  sync headers from peer timeout, restart sync
```
- Remove nil handling of GetIndexBestHeader
    - The bestHeader will be set during lchain.InitGenesisChain(), so after
    appInitMain the bestHeader will at least be GenesisBlock

- Use lightweight IsInitialBlockDownload avoid chain tip access data race

