### PR TITLE
Remove logs in fetchHeaderBlocks for issue #216

### DIFF
--- a/model/block/block.go
+++ b/model/block/block.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"io"
 
-	"github.com/copernet/copernicus/log"
 	"github.com/copernet/copernicus/logic/lmerkleroot"
 	"github.com/copernet/copernicus/model/tx"
 	"github.com/copernet/copernicus/util"
@@ -30,7 +29,6 @@ func (bl *Block) SetNull() {
 }
 
 func (bl *Block) Serialize(w io.Writer) error {
-	log.Trace("block Serialize....")
 	if err := bl.Header.Serialize(w); err != nil {
 		return err
 	}
@@ -72,7 +70,6 @@ func (bl *Block) EncodeSize() int {
 }
 
 func (bl *Block) Unserialize(r io.Reader) error {
-	log.Trace("block Unserialize.... ")
 	if err := bl.Header.Unserialize(r); err != nil {
 		return err
 	}

--- a/model/chain/chain.go
+++ b/model/chain/chain.go
@@ -406,10 +406,6 @@ func (c *Chain) GetLocator(index *blockindex.BlockIndex) *BlockLocator {
 			index = index.GetAncestor(height)
 		}
 
-		if len(blockHashList) < 2 {
-			log.Trace("GetLocator from hash : %s, height : %d .",
-				index.GetBlockHash(), index.Height)
-		}
 		if len(blockHashList) > 10 {
 			step *= 2
 		}

--- a/net/wire/message.go
+++ b/net/wire/message.go
@@ -417,7 +417,7 @@ func ReadMessageWithEncodingN(r io.Reader, pver uint32, btcnet BitcoinNet,
 	// Unmarshal message.  NOTE: This must be a *bytes.Buffer since the
 	// MsgVersion Decode function requires it.
 	pr := bytes.NewBuffer(payload)
-	log.Trace("begin Decode msg ....")
+
 	err = msg.Decode(pr, pver, enc)
 	if err != nil {
 		log.Error("decode error: %v", err)


### PR DESCRIPTION
- remove logs in fetchHeaderBlocks
- extend fetch loop timer to 20s


logs before fix:
```
root@server:~/.bitcoincash/testnet# du -sh *
4.0K	banpeers.json
11G	blocks
927M	chainstate
24G	logs



2018/12/10 09:41:00.393 [I] [syncmanager.go:685]  peer(2177) best known block nil, forgive temporary
2018/12/10 09:41:00.393 [D] [chain.go:410]  GetLocator from hash : 0000000000006092cf364fd6d3812013e22ce7f25dd1f8934a0da7e46339c9d2, height : 1273259 .
2018/12/10 09:41:00.393 [D] [syncmanager.go:761]  fetchHeaderBlocks can not find block hashes to fetch from peer(2177)
2018/12/10 09:41:00.393 [I] [syncmanager.go:766]  peer(22) ChainWork less than minChainWork, do not use this peer
2018/12/10 09:41:00.393 [I] [syncmanager.go:685]  peer(771) best known block nil, forgive temporary
2018/12/10 09:41:00.393 [D] [chain.go:410]  GetLocator from hash : 0000000000006092cf364fd6d3812013e22ce7f25dd1f8934a0da7e46339c9d2, height : 1273259 .
2018/12/10 09:41:00.393 [D] [syncmanager.go:761]  fetchHeaderBlocks can not find block hashes to fetch from peer(771)
2018/12/10 09:41:00.393 [I] [syncmanager.go:685]  peer(855) best known block nil, forgive temporary
2018/12/10 09:41:00.393 [D] [chain.go:410]  GetLocator from hash : 0000000000006092cf364fd6d3812013e22ce7f25dd1f8934a0da7e46339c9d2, height : 1273259 .
2018/12/10 09:41:00.393 [D] [syncmanager.go:761]  fetchHeaderBlocks can not find block hashes to fetch from peer(855)
2018/12/10 09:41:00.393 [I] [syncmanager.go:685]  peer(1306) best known block nil, forgive temporary
2018/12/10 09:41:00.393 [D] [chain.go:410]  GetLocator from hash : 0000000000006092cf364fd6d3812013e22ce7f25dd1f8934a0da7e46339c9d2, height : 1273259 .
2018/12/10 09:41:00.393 [D] [syncmanager.go:761]  fetchHeaderBlocks can not find block hashes to fetch from peer(1306)
2018/12/10 09:41:00.393 [I] [syncmanager.go:685]  peer(1405) best known block nil, forgive temporary


```