### PR TITLE
add detailed RevertToInv check; add pindexBestHeaderSent

### DIFF
--- a/net/server/server.go
+++ b/net/server/server.go
@@ -817,6 +817,16 @@ func (sp *serverPeer) OnGetHeaders(_ *peer.Peer, msg *wire.MsgGetHeaders) {
 	for i := range headers {
 		blockHeaders[i] = &headers[i]
 	}
+	var idx *blockindex.BlockIndex
+	gChain := chain.GetInstance()
+	if len(headers) != 0 {
+		hash := headers[len(headers)-1].GetHash()
+		idx = gChain.FindBlockIndex(hash)
+	}
+	if idx == nil {
+		idx = gChain.Tip()
+	}
+	sp.UpdateIndexBestHeaderSent(idx)
 	sp.QueueMessage(&wire.MsgHeaders{Headers: blockHeaders}, nil)
 }
 

--- a/net/server/server.go
+++ b/net/server/server.go
@@ -811,10 +811,6 @@ func (sp *serverPeer) OnGetHeaders(_ *peer.Peer, msg *wire.MsgGetHeaders) {
 	//
 	// This mirrors the behavior in the reference implementation.
 	headers := lchain.LocateHeaders(chain.NewBlockLocator(hashpointer2hashinstance(msg.BlockLocatorHashes)), &msg.HashStop)
-	if len(headers) == 0 {
-		// Nothing to send.
-		return
-	}
 
 	// Send found headers to the requesting peer.
 	blockHeaders := make([]*block.BlockHeader, len(headers))

--- a/net/server/server.go
+++ b/net/server/server.go
@@ -1303,7 +1303,6 @@ func (s *Server) handleUpdatePeerHeights(state *peerState, umsg updatePeerHeight
 		// height.
 		if *latestBlkHash == *umsg.newHash {
 			sp.UpdateLastBlockHeight(umsg.newHeight)
-			sp.UpdateLastAnnouncedBlock(nil)
 		}
 	})
 }

--- a/net/server/server_test.go
+++ b/net/server/server_test.go
@@ -1351,7 +1351,7 @@ func TestServer_UpdatePeerHeights(t *testing.T) {
 	sp.UpdateLastAnnouncedBlock(blockHash)
 	sp.UpdateLastBlockHeight(3)
 	svr.handleUpdatePeerHeights(&ps, updateMsg)
-	assert.Nil(t, sp.LastAnnouncedBlock())
+	assert.NotNil(t, sp.LastAnnouncedBlock())
 	assert.Equal(t, int32(4), sp.LastBlock())
 
 	// not update for no last announced block

--- a/net/syncmanager/syncmanager.go
+++ b/net/syncmanager/syncmanager.go
@@ -198,6 +198,9 @@ type peerSyncState struct {
 	requestedBlocks     map[util.Hash]struct{}
 	unconnectingHeaders int
 	headersSyncTimeout  int64
+	// syncStarted indicate whether we have send a GetHeaders msg from the peer
+	// when the pindexBestHeader is 24h near to now, to fetch all possible header
+	syncStarted bool
 }
 
 func (pss *peerSyncState) onStartSync(syncPeer *peer.Peer) {
@@ -1235,11 +1238,38 @@ func limitMap(m map[util.Hash]struct{}, limit int) {
 	}
 }
 
+func (sm *SyncManager) checkSyncHeaderOnce(p *peer.Peer, state *peerSyncState) {
+	if p == nil || state == nil {
+		return
+	}
+
+	if state.syncStarted {
+		return
+	}
+
+	gChain := chain.GetInstance()
+	bestHeader := gChain.GetIndexBestHeader()
+
+	if int64(bestHeader.GetBlockTime()) <= util.GetAdjustedTimeSec()-24*60*60 {
+		return
+	}
+
+	state.syncStarted = true
+
+	if bestHeader.Prev != nil {
+		bestHeader = bestHeader.Prev
+	}
+	locator := gChain.GetLocator(bestHeader)
+	p.PushGetHeadersMsg(*locator, &zeroHash)
+}
+
 func (sm *SyncManager) scanToFetchHeaderBlocks() {
 	for peer, state := range sm.peerStates {
 		if !state.syncCandidate {
 			continue
 		}
+
+		sm.checkSyncHeaderOnce(peer, state)
 
 		// detect whether we're stalling the concurrent download window
 		now := time.Now().UnixNano() / 1000

--- a/net/syncmanager/syncmanager.go
+++ b/net/syncmanager/syncmanager.go
@@ -1116,14 +1116,6 @@ func (sm *SyncManager) handleInvMsg(imsg *invMsg) {
 
 	if lastBlock != -1 {
 		peer.CheckRevertToInv(&invVects[lastBlock].Hash, true)
-	}
-
-	// If this inv contains a block announcement, and this isn't coming from
-	// our current sync peer or we're current, then update the last
-	// announced block for this peer. We'll use this information later to
-	// update the heights of peers based on blocks we've accepted that they
-	// previously announced.
-	if lastBlock != -1 && (peer != sm.syncPeer || sm.current()) {
 		peer.UpdateLastAnnouncedBlock(&invVects[lastBlock].Hash)
 	}
 

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -1679,18 +1679,12 @@ func (p *Peer) PeerHasHeader(idx *blockindex.BlockIndex) bool {
 		p.UpdateLastAnnouncedBlock(hash)
 	}
 	pindex := gChain.FindBlockIndex(*hash)
-	if pindex == nil {
-		return false
-	}
-	if idx == pindex.GetAncestor(idx.Height) {
+	if pindex != nil && idx == pindex.GetAncestor(idx.Height) {
 		return true
 	}
 
 	idxBestSent := p.IndexBestHeaderSent()
-	if idxBestSent == nil {
-		return false
-	}
-	if idx == idxBestSent.GetAncestor(idx.Height) {
+	if idxBestSent != nil && idx == idxBestSent.GetAncestor(idx.Height) {
 		return true
 	}
 	return false


### PR DESCRIPTION
1, Fix issue #211, add detailed RevertToInv check.
2, Fix issue #224, send GetHeaders msg once, when pindexBestHeader is 24h near to now, which will let us know all available headers, and thus find most pow work header.
3, add support of pindexBestHeaderSent variable, which we do not implement in previous code. But this variable is needed to when fixing issue #211.
4, some old bug found and fixed.

All FT & UT run passed.

And I am testing these code on mainnet, until now everything goes well.

@whunmr please help review the code.