### PR TITLE
 Fix data race in GetTxoutSetInfo for issue #226

### DIFF
--- a/model/chain/chain.go
+++ b/model/chain/chain.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/copernet/copernicus/model/pow"
 	"github.com/copernet/copernicus/model/script"
@@ -172,27 +171,6 @@ func (c *Chain) TipHeight() int32 {
 	}
 
 	return 0
-}
-
-// IsCurrent returns whether or not the chain believes it is current.  Several
-// factors are used to guess, but the key factors that allow the chain to
-// believe it is current are:
-//  - Latest block height is after the latest checkpoint (if enabled)
-//  - Latest block has a timestamp newer than 24 hours ago
-func (c *Chain) IsCurrent() bool {
-	// Not current if the latest main (best) chain height is before the
-	// latest known good checkpoint (when checkpoints are enabled).
-	//TODO: checkpoint
-	//checkpoint := b.LatestCheckpoint()
-	//if checkpoint != nil && b.bestChain.Tip().height < checkpoint.Height {
-	//	return false
-	//}
-
-	// Not current if the latest best block has a timestamp before 24 hours ago.
-	minus24Hours := time.Unix(util.GetTimeSec(), 0).Add(-24 * time.Hour).Unix()
-	tipTime := int64(c.Tip().GetBlockTime())
-
-	return tipTime >= minus24Hours
 }
 
 func (c *Chain) GetSpendHeight(hash *util.Hash) int32 {
@@ -628,6 +606,7 @@ func (c *Chain) ChainOrphanLen() int32 {
 
 func (c *Chain) ClearActive() {
 	c.active = make([]*blockindex.BlockIndex, 100)
+	c.tip = atomic.Value{}
 }
 
 func (c *Chain) IndexMapSize() int {

--- a/model/chain/chain.go
+++ b/model/chain/chain.go
@@ -301,8 +301,11 @@ func (c *Chain) Next(index *blockindex.BlockIndex) *blockindex.BlockIndex {
 // Height Return the maximal height in the chain. Is equal to chain.Tip() ?
 // chain.Tip()->nHeight : -1.
 func (c *Chain) Height() int32 {
-	chainLen := int32(len(c.active))
-	return chainLen - 1
+	if t := c.Tip(); t != nil {
+		return t.Height
+	}
+
+	return -1
 }
 
 // SetTip Set/initialize a chain with a given tip.

--- a/model/chain/chain_test.go
+++ b/model/chain/chain_test.go
@@ -50,13 +50,13 @@ func TestChain_Simple(t *testing.T) {
 	bIndex[0] = blockindex.NewBlockIndex(&model.ActiveNetParams.GenesisBlock.Header)
 	tChain.AddToBranch(bIndex[0])
 	tChain.AddToIndexMap(bIndex[0])
-	tChain.active = append(tChain.active, bIndex[0])
+	tChain.SetTip(bIndex[0])
 
 	for height = 1; height < 11; height++ {
 		bIndex[height] = getBlockIndex(bIndex[height-1], timePerBlock, initBits)
 		tChain.AddToBranch(bIndex[height])
 		tChain.AddToIndexMap(bIndex[height])
-		tChain.active = append(tChain.active, bIndex[height])
+		tChain.SetTip(bIndex[height])
 	}
 	for height = 11; height < 16; height++ {
 		bIndex[height] = getBlockIndex(bIndex[height-1], timePerBlock, initBits)
@@ -82,9 +82,7 @@ func TestChain_Simple(t *testing.T) {
 	if tChain.TipHeight() != 10 {
 		t.Errorf("TipHeight Error")
 	}
-	if tChain.IsCurrent() {
-		t.Errorf("IsCurrent Error")
-	}
+
 	if tChain.GetSpendHeight(bIndex[15].GetBlockHash()) != 16 {
 		t.Errorf("GetSpendHeight Error")
 	}
@@ -127,7 +125,6 @@ func TestChain_Simple(t *testing.T) {
 	if tChain.ClearActive(); tChain.Tip() != nil {
 		t.Errorf("ClearActive Error")
 	}
-
 }
 
 func TestChain_Fork(t *testing.T) {
@@ -146,19 +143,18 @@ func TestChain_Fork(t *testing.T) {
 	bIndex[0] = blockindex.NewBlockIndex(&model.ActiveNetParams.GenesisBlock.Header)
 	tChain.AddToIndexMap(bIndex[0])
 	tChain.AddToBranch(bIndex[0])
-	tChain.active = append(tChain.active, bIndex[0])
+	tChain.SetTip(bIndex[0])
 
 	for height = 1; height < 11; height++ {
 		bIndex[height] = getBlockIndex(bIndex[height-1], timePerBlock, initBits)
 		tChain.AddToBranch(bIndex[height])
 		tChain.AddToIndexMap(bIndex[height])
-		tChain.active = append(tChain.active, bIndex[height])
+		tChain.SetTip(bIndex[height])
 	}
 	for height = 5; height < 15; height++ {
 		bIndex[height] = getBlockIndex(bIndex[height-1], timePerBlock-1, initBits)
 		tChain.AddToBranch(bIndex[height])
 		tChain.AddToIndexMap(bIndex[height])
-		tChain.active = append(tChain.active, bIndex[height])
 	}
 
 	if tChain.FindFork(bIndex[9]) != bIndex[4] {
@@ -167,6 +163,7 @@ func TestChain_Fork(t *testing.T) {
 
 	setTips := set.New()
 	setTips.Add(tChain.Tip())
+	setTips.Add(bIndex[14])
 
 	if !tChain.GetChainTips().IsEqual(setTips) {
 		t.Errorf("GetChainTips Error")
@@ -177,6 +174,7 @@ func TestChain_Fork(t *testing.T) {
 func TestChain_InitLoad(t *testing.T) {
 	InitGlobalChain()
 	tChain := GetInstance()
+	tChain.ClearActive()
 
 	tChain.indexMap = make(map[util.Hash]*blockindex.BlockIndex)
 	bIndex := make([]*blockindex.BlockIndex, 50)
@@ -237,13 +235,13 @@ func TestChain_InitLoad(t *testing.T) {
 	bIndex[0] = blockindex.NewBlockIndex(&model.ActiveNetParams.GenesisBlock.Header)
 	tChain.AddToBranch(bIndex[0])
 	tChain.AddToIndexMap(bIndex[0])
-	tChain.active = append(tChain.active, bIndex[0])
+	tChain.SetTip(bIndex[0])
 
 	for height = 1; height < 11; height++ {
 		bIndex[height] = getBlockIndex(bIndex[height-1], timePerBlock, initBits)
 		tChain.AddToBranch(bIndex[height])
 		tChain.AddToIndexMap(bIndex[height])
-		tChain.active = append(tChain.active, bIndex[height])
+		tChain.SetTip(bIndex[height])
 	}
 	if tChain.SetTip(nil); tChain.Tip() != nil {
 		t.Errorf("SetTip Error")

--- a/net/syncmanager/syncmanager.go
+++ b/net/syncmanager/syncmanager.go
@@ -8,6 +8,7 @@ import (
 	"container/list"
 	"github.com/copernet/copernicus/logic/lblock"
 	"github.com/copernet/copernicus/model/pow"
+	"github.com/copernet/copernicus/persist"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -760,6 +761,8 @@ func (sm *SyncManager) syncPoints(peer *peer.Peer) (pindexWalk, pindexBestKnownB
 		return gChain.Tip(), pindexBestKnownBlock
 	}
 
+	persist.CsMain.RLock()
+	defer persist.CsMain.RUnlock()
 	return gChain.FindFork(pindexBestKnownBlock), pindexBestKnownBlock
 }
 

--- a/rpc/rpcblockchain.go
+++ b/rpc/rpcblockchain.go
@@ -751,6 +751,9 @@ func handleGetTxOut(s *Server, cmd interface{}, closeChan <-chan struct{}) (inte
 }
 
 func handleGetTxoutSetInfo(s *Server, cmd interface{}, closeChan <-chan struct{}) (interface{}, error) {
+	persist.CsMain.Lock()
+	defer persist.CsMain.Unlock()
+
 	// Write the chain state to disk, if necessary.
 	if err := disk.FlushStateToDisk(disk.FlushStateAlways, 0); err != nil {
 		return nil, err

--- a/service/blockservice.go
+++ b/service/blockservice.go
@@ -14,6 +14,10 @@ import (
 
 func ProcessBlockHeader(headerList []*block.BlockHeader, lastIndex *blockindex.BlockIndex) error {
 	log.Debug("ProcessBlockHeader begin, header number : %d", len(headerList))
+
+	persist.CsMain.Lock()
+	defer persist.CsMain.Unlock()
+
 	lastheight := int32(-1)
 	for _, header := range headerList {
 		index, err := lblock.AcceptBlockHeader(header)


### PR DESCRIPTION
fix data race in #226 

and another two data races:

```
==================
WARNING: DATA RACE
Write at 0x00c0000ec210 by goroutine 82:
  github.com/copernet/copernicus/model/chain.(*Chain).SetTip()
      /Users/bj1809120051/.go/src/github.com/copernet/copernicus/model/chain/chain.go:345 +0x3d1
  github.com/copernet/copernicus/logic/lchain.UpdateTip()
      /Users/bj1809120051/.go/src/github.com/copernet/copernicus/logic/lchain/lchain.go:390 +0x96
  github.com/copernet/copernicus/logic/lchain.ConnectTip()
      /Users/bj1809120051/.go/src/github.com/copernet/copernicus/logic/lchain/lchain.go:301 +0x1db0
  github.com/copernet/copernicus/logic/lchain.ActivateBestChainStep()
      /Users/bj1809120051/.go/src/github.com/copernet/copernicus/logic/lchain/lactivechain.go:186 +0x750
  github.com/copernet/copernicus/logic/lchain.ActivateBestChain()
      /Users/bj1809120051/.go/src/github.com/copernet/copernicus/logic/lchain/lactivechain.go:85 +0x5c1
  github.com/copernet/copernicus/service.ProcessNewBlock()
      /Users/bj1809120051/.go/src/github.com/copernet/copernicus/service/blockservice.go:97 +0x92e
  github.com/copernet/copernicus/service.ProcessBlock()
      /Users/bj1809120051/.go/src/github.com/copernet/copernicus/service/blockservice.go:51 +0x75b
  github.com/copernet/copernicus/net/syncmanager.(*SyncManager).handleBlockMsg()
      /Users/bj1809120051/.go/src/github.com/copernet/copernicus/net/syncmanager/syncmanager.go:650 +0x563
  github.com/copernet/copernicus/net/syncmanager.(*SyncManager).messagesHandler()
      /Users/bj1809120051/.go/src/github.com/copernet/copernicus/net/syncmanager/syncmanager.go:1301 +0xc38

Previous read at 0x00c0000ec210 by goroutine 135:
  github.com/copernet/copernicus/model/chain.(*Chain).TipHeight()
      /Users/bj1809120051/.go/src/github.com/copernet/copernicus/model/chain/chain.go:170 +0x50
  github.com/copernet/copernicus/rpc.handleWaitForBlockHeight()
      /Users/bj1809120051/.go/src/github.com/copernet/copernicus/rpc/rpcblockchain.go:1007 +0x29b
  github.com/copernet/copernicus/rpc.(*Server).standardCmdResult()
      /Users/bj1809120051/.go/src/github.com/copernet/copernicus/rpc/rpcserver.go:217 +0x1f6
  github.com/copernet/copernicus/rpc.(*Server).jsonRPCRead()
      /Users/bj1809120051/.go/src/github.com/copernet/copernicus/rpc/rpcserver.go:378 +0x1d4a
  github.com/copernet/copernicus/rpc.(*Server).Start.func1()
      /Users/bj1809120051/.go/src/github.com/copernet/copernicus/rpc/rpcserver.go:448 +0x43e
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/opt/go/libexec/src/net/http/server.go:1964 +0x6f
  net/http.(*ServeMux).ServeHTTP()
      /usr/local/opt/go/libexec/src/net/http/server.go:2361 +0x2cb
  net/http.serverHandler.ServeHTTP()
      /usr/local/opt/go/libexec/src/net/http/server.go:2741 +0x34e
  net/http.(*conn).serve()
      /usr/local/opt/go/libexec/src/net/http/server.go:1847 +0x1f7b




==================
==================
WARNING: DATA RACE
Write at 0x00c0000fe0c0 by goroutine 76:
  github.com/copernet/copernicus/model/chain.(*Chain).SetTip()
      /Users/bj1809120051/.go/src/github.com/copernet/copernicus/model/chain/chain.go:328 +0x3e4
  github.com/copernet/copernicus/logic/lchain.UpdateTip()
      /Users/bj1809120051/.go/src/github.com/copernet/copernicus/logic/lchain/lchain.go:390 +0x96
  github.com/copernet/copernicus/logic/lchain.DisconnectTip()
      /Users/bj1809120051/.go/src/github.com/copernet/copernicus/logic/lchain/lchain.go:367 +0x989
  github.com/copernet/copernicus/rpc.handleInvalidateBlock()
      /Users/bj1809120051/.go/src/github.com/copernet/copernicus/rpc/rpcblockchain.go:900 +0x57e
  github.com/copernet/copernicus/rpc.(*Server).standardCmdResult()
      /Users/bj1809120051/.go/src/github.com/copernet/copernicus/rpc/rpcserver.go:217 +0x1f6
  github.com/copernet/copernicus/rpc.(*Server).jsonRPCRead()
      /Users/bj1809120051/.go/src/github.com/copernet/copernicus/rpc/rpcserver.go:378 +0x1d4a
  github.com/copernet/copernicus/rpc.(*Server).Start.func1()
      /Users/bj1809120051/.go/src/github.com/copernet/copernicus/rpc/rpcserver.go:448 +0x43e
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/opt/go/libexec/src/net/http/server.go:1964 +0x6f
  net/http.(*ServeMux).ServeHTTP()
      /usr/local/opt/go/libexec/src/net/http/server.go:2361 +0x2cb
  net/http.serverHandler.ServeHTTP()
      /usr/local/opt/go/libexec/src/net/http/server.go:2741 +0x34e
  net/http.(*conn).serve()
      /usr/local/opt/go/libexec/src/net/http/server.go:1847 +0x1f7b

Previous read at 0x00c0000fe0c0 by goroutine 83:
  github.com/copernet/copernicus/model/chain.(*Chain).GetIndex()
      /Users/bj1809120051/.go/src/github.com/copernet/copernicus/model/chain/chain.go:264 +0x74
  github.com/copernet/copernicus/model/chain.(*Chain).Contains()
      /Users/bj1809120051/.go/src/github.com/copernet/copernicus/model/chain/chain.go:286 +0x8d
  github.com/copernet/copernicus/model/chain.(*Chain).FindFork()
      /Users/bj1809120051/.go/src/github.com/copernet/copernicus/model/chain/chain.go:410 +0x135
  github.com/copernet/copernicus/net/syncmanager.(*SyncManager).syncPoints()
      /Users/bj1809120051/.go/src/github.com/copernet/copernicus/net/syncmanager/syncmanager.go:763 +0x268
  github.com/copernet/copernicus/net/syncmanager.(*SyncManager).fetchHeaderBlocks()
      /Users/bj1809120051/.go/src/github.com/copernet/copernicus/net/syncmanager/syncmanager.go:793 +0x37b
  github.com/copernet/copernicus/net/syncmanager.(*SyncManager).handleBlockMsg()
      /Users/bj1809120051/.go/src/github.com/copernet/copernicus/net/syncmanager/syncmanager.go:707 +0x102f
  github.com/copernet/copernicus/net/syncmanager.(*SyncManager).messagesHandler()
      /Users/bj1809120051/.go/src/github.com/copernet/copernicus/net/syncmanager/syncmanager.go:1301 +0xc38


 
```