### PR TITLE
Remove unnecessary read lock in CheckTxBeforeAcceptToMemPool

### DIFF
--- a/logic/ltx/ltx.go
+++ b/logic/ltx/ltx.go
@@ -102,8 +102,6 @@ func CheckTxBeforeAcceptToMemPool(txn *tx.Tx) (*mempool.TxEntry, error) {
 
 	// is mempool already have it? conflict tx with mempool
 	gPool := mempool.GetInstance()
-	gPool.RLock()
-	defer gPool.RUnlock()
 	if gPool.FindTx(txn.GetHash()) != nil {
 		log.Debug("tx already known in mempool, hash: %s", txn.GetHash())
 		return nil, errcode.NewError(errcode.RejectAlreadyKnown, "txn-already-in-mempool")


### PR DESCRIPTION
Mempool mutex 'RLock' is called outside and inside FindTx() in function 'CheckTxBeforeAcceptToMemPool'.
Goroutine might be blocked if a write Lock called between twice RLock.
(peerDoneHandler -> RemoveOrphansByTag -> mempool.(*TxMempool).Lock)